### PR TITLE
Historical queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ## IAVL+ Tree
 
-A snapshottable (immutable) AVL+ tree for persistent data
-
-**Note** Please make sure you read the [caveat](https://github.com/tendermint/merkleeyes/blob/develop/iavl/iavl_tree.go#L34-L40) on `Copy`. If you have a backing DB and call `Save` to persist the state, all existing copies become potentially invalid and may panic if used. For safe coding, you must throw away all references upon save, and `Copy` again from the new, committed state.
+A versioned, snapshottable (immutable) AVL+ tree for persistent data.
 
 The purpose of this data structure is to provide persistent storage for key-value pairs (say to store account balances) such that a deterministic merkle root hash can be computed.  The tree is balanced using a variant of the [AVL algortihm](http://en.wikipedia.org/wiki/AVL_tree) so all operations are O(log(n)).
 
-Nodes of this tree are immutable and indexed by its hash.  Thus any node serves as an immutable snapshot which lets us stage uncommitted transactions from the mempool cheaply, and we can instantly roll back to the last committed state to process transactions of a newly committed block (which may not be the same set of transactions as those from the mempool).
+Nodes of this tree are immutable and indexed by their hash.  Thus any node serves as an immutable snapshot which lets us stage uncommitted transactions from the mempool cheaply, and we can instantly roll back to the last committed state to process transactions of a newly committed block (which may not be the same set of transactions as those from the mempool).
 
 In an AVL tree, the heights of the two child subtrees of any node differ by at most one.  Whenever this condition is violated upon an update, the tree is rebalanced by creating O(log(n)) new nodes that point to unmodified nodes of the old tree.  In the original AVL algorithm, inner nodes can also hold key-value pairs.  The AVL+ algorithm (note the plus) modifies the AVL algorithm to keep all values on leaf nodes, while only using branch-nodes to store keys.  This simplifies the algorithm while keeping the merkle hash trail short.
 

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -115,7 +115,6 @@ func (node *IAVLNode) clone() *IAVLNode {
 	}
 	return &IAVLNode{
 		key:       node.key,
-		value:     node.value,
 		height:    node.height,
 		version:   node.version,
 		size:      node.size,

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -110,6 +110,9 @@ func (node *IAVLNode) debugString() string {
 
 // clone creates a shallow copy of a node with its hash set to nil.
 func (node *IAVLNode) clone() *IAVLNode {
+	if node.isLeaf() {
+		cmn.PanicSanity("Attempt to copy a leaf node")
+	}
 	return &IAVLNode{
 		key:       node.key,
 		value:     node.value,

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -351,7 +351,7 @@ func (node *IAVLNode) remove(t *IAVLTree, key []byte) (
 		if bytes.Equal(key, node.key) {
 			return nil, nil, nil, node.value, []*IAVLNode{node}
 		}
-		return node.hash, node, nil, nil, []*IAVLNode{}
+		return node.hash, node, nil, nil, orphaned
 	}
 
 	if bytes.Compare(key, node.key) < 0 {
@@ -362,7 +362,7 @@ func (node *IAVLNode) remove(t *IAVLTree, key []byte) (
 			node.getLeftNode(t).remove(t, key)
 
 		if len(orphaned) == 0 {
-			return node.hash, node, nil, value, []*IAVLNode{}
+			return node.hash, node, nil, value, orphaned
 		} else if newLeftHash == nil && newLeftNode == nil { // left node held value, was removed
 			return node.rightHash, node.rightNode, node.key, value, orphaned
 		}
@@ -382,7 +382,7 @@ func (node *IAVLNode) remove(t *IAVLTree, key []byte) (
 			node.getRightNode(t).remove(t, key)
 
 		if len(orphaned) == 0 {
-			return node.hash, node, nil, value, []*IAVLNode{}
+			return node.hash, node, nil, value, orphaned
 		} else if newRightHash == nil && newRightNode == nil { // right node held value, was removed
 			return node.leftHash, node.leftNode, nil, value, orphaned
 		}

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -414,9 +414,9 @@ func (node *IAVLNode) getRightNode(t *IAVLTree) *IAVLNode {
 	return t.ndb.GetNode(node.rightHash)
 }
 
-// NOTE: overwrites node
-// TODO: optimize balance & rotate
-func (node *IAVLNode) rotateRight(t *IAVLTree) (*IAVLNode, *IAVLNode) {
+// Rotate right and return the new node and orphan.
+func (node *IAVLNode) rotateRight(t *IAVLTree) (newNode *IAVLNode, orphan *IAVLNode) {
+	// TODO: optimize balance & rotate.
 	node = node.clone()
 	l := node.getLeftNode(t)
 	_l := l.clone()
@@ -431,9 +431,9 @@ func (node *IAVLNode) rotateRight(t *IAVLTree) (*IAVLNode, *IAVLNode) {
 	return _l, l
 }
 
-// NOTE: overwrites node
-// TODO: optimize balance & rotate
-func (node *IAVLNode) rotateLeft(t *IAVLTree) (*IAVLNode, *IAVLNode) {
+// Rotate left and return the new node and orphan.
+func (node *IAVLNode) rotateLeft(t *IAVLTree) (newNode *IAVLNode, orphan *IAVLNode) {
+	// TODO: optimize balance & rotate.
 	node = node.clone()
 	r := node.getRightNode(t)
 	_r := r.clone()

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -335,8 +335,8 @@ func (node *IAVLNode) set(t *IAVLTree, key []byte, value []byte) (
 			return node, updated, orphaned
 		} else {
 			node.calcHeightAndSize(t)
-			new, balanceOrphaned := node.balance(t)
-			return new, updated, append(orphaned, balanceOrphaned...)
+			newNode, balanceOrphaned := node.balance(t)
+			return newNode, updated, append(orphaned, balanceOrphaned...)
 		}
 	}
 }
@@ -469,8 +469,8 @@ func (node *IAVLNode) balance(t *IAVLTree) (newSelf *IAVLNode, orphaned []*IAVLN
 	if balance > 1 {
 		if node.getLeftNode(t).calcBalance(t) >= 0 {
 			// Left Left Case
-			new, orphaned := node.rotateRight(t)
-			return new, []*IAVLNode{orphaned}
+			newNode, orphaned := node.rotateRight(t)
+			return newNode, []*IAVLNode{orphaned}
 		} else {
 			// Left Right Case
 			var leftOrphaned *IAVLNode
@@ -478,16 +478,16 @@ func (node *IAVLNode) balance(t *IAVLTree) (newSelf *IAVLNode, orphaned []*IAVLN
 			left := node.getLeftNode(t)
 			node.leftHash = nil
 			node.leftNode, leftOrphaned = left.rotateLeft(t)
-			new, rightOrphaned := node.rotateRight(t)
+			newNode, rightOrphaned := node.rotateRight(t)
 
-			return new, []*IAVLNode{left, leftOrphaned, rightOrphaned}
+			return newNode, []*IAVLNode{left, leftOrphaned, rightOrphaned}
 		}
 	}
 	if balance < -1 {
 		if node.getRightNode(t).calcBalance(t) <= 0 {
 			// Right Right Case
-			new, orphaned := node.rotateLeft(t)
-			return new, []*IAVLNode{orphaned}
+			newNode, orphaned := node.rotateLeft(t)
+			return newNode, []*IAVLNode{orphaned}
 		} else {
 			// Right Left Case
 			var rightOrphaned *IAVLNode
@@ -495,9 +495,9 @@ func (node *IAVLNode) balance(t *IAVLTree) (newSelf *IAVLNode, orphaned []*IAVLN
 			right := node.getRightNode(t)
 			node.rightHash = nil
 			node.rightNode, rightOrphaned = right.rotateRight(t)
-			new, leftOrphaned := node.rotateLeft(t)
+			newNode, leftOrphaned := node.rotateLeft(t)
 
-			return new, []*IAVLNode{right, leftOrphaned, rightOrphaned}
+			return newNode, []*IAVLNode{right, leftOrphaned, rightOrphaned}
 		}
 	}
 	// Nothing changed

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -110,11 +110,9 @@ func (node *IAVLNode) debugString() string {
 
 // clone creates a shallow copy of a node with its hash set to nil.
 func (node *IAVLNode) clone() *IAVLNode {
-	if node.isLeaf() {
-		cmn.PanicSanity("Why are you copying a value node?")
-	}
 	return &IAVLNode{
 		key:       node.key,
+		value:     node.value,
 		height:    node.height,
 		version:   node.version,
 		size:      node.size,

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -224,7 +224,10 @@ func (ndb *nodeDB) deleteOrphans(version uint64) {
 		// See comment on `orphansKeyFmt`. Note that here, `version` and
 		// `toVersion` are always equal.
 		fmt.Sscanf(string(key), orphansKeyFmt, &toVersion, &fromVersion)
+
+		// Delete orphan key and reverse-lookup key.
 		ndb.batch.Delete(key)
+		ndb.batch.Delete([]byte(fmt.Sprintf(orphansIndexKeyFmt, hash)))
 
 		// If there is no predecessor, or the predecessor is earlier than the
 		// beginning of the lifetime (ie: negative lifetime), or the lifetime

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -284,7 +284,7 @@ func (ndb *nodeDB) cacheVersion(version uint64, hash []byte) {
 func (ndb *nodeDB) getPreviousVersion(version uint64) uint64 {
 	var result uint64 = 0
 	for v, _ := range ndb.getVersions() {
-		if v < version && (result == 0 || v > result) {
+		if v < version && v > result {
 			result = v
 		}
 	}

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -147,27 +147,29 @@ func (ndb *nodeDB) Has(hash []byte) bool {
 //
 // Note that this function clears leftNode/rigthNode recursively and calls
 // hashWithCount on the given node.
-func (ndb *nodeDB) SaveBranch(node *IAVLNode, cb func(*IAVLNode)) {
+func (ndb *nodeDB) SaveBranch(node *IAVLNode, cb func(*IAVLNode)) []byte {
 	if node.persisted {
-		return
+		return node.hash
 	}
 
 	if node.leftNode != nil {
-		ndb.SaveBranch(node.leftNode, cb)
+		node.leftHash = ndb.SaveBranch(node.leftNode, cb)
 	}
 	if node.rightNode != nil {
-		ndb.SaveBranch(node.rightNode, cb)
+		node.rightHash = ndb.SaveBranch(node.rightNode, cb)
 	}
 
 	if cb != nil {
 		cb(node)
 	}
 
-	node.hashWithCount()
+	hash := node._hash()
 	ndb.SaveNode(node)
 
 	node.leftNode = nil
 	node.rightNode = nil
+
+	return hash
 }
 
 // DeleteVersion deletes a tree version from disk.

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -152,7 +152,6 @@ func (ndb *nodeDB) DeleteVersion(version uint64) {
 
 	ndb.deleteOrphans(version)
 	ndb.deleteRoot(version)
-	ndb.cleanup()
 }
 
 // Unorphan deletes the orphan entry from disk, but not the node it points to.
@@ -184,18 +183,6 @@ func (ndb *nodeDB) SaveOrphans(version uint64, orphans map[string]uint64) {
 func (ndb *nodeDB) saveOrphan(hash []byte, fromVersion, toVersion uint64) {
 	key := fmt.Sprintf(orphansKeyFmt, toVersion, fromVersion, hash)
 	ndb.batch.Set([]byte(key), hash)
-}
-
-// Cleanup is called after a version is deleted.
-func (ndb *nodeDB) cleanup() {
-	// If only one version is left, we can cleanup all orphans, they aren't
-	// needed anymore.
-	if len(ndb.getVersions()) == 1 {
-		ndb.traverseOrphansVersion(ndb.getLatestVersion(), func(key, value []byte) {
-			ndb.batch.Delete(key)
-			ndb.batch.Delete(value)
-		})
-	}
 }
 
 // deleteOrphans deletes orphaned nodes from disk, and the associated orphan

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -148,26 +148,26 @@ func (ndb *nodeDB) Has(hash []byte) bool {
 // Note that this function clears leftNode/rigthNode recursively and calls
 // hashWithCount on the given node.
 func (ndb *nodeDB) SaveBranch(node *IAVLNode, cb func(*IAVLNode)) {
-	if node.hash == nil {
-		node.hash, _ = node.hashWithCount()
-	}
 	if node.persisted {
 		return
 	}
 
 	if node.leftNode != nil {
 		ndb.SaveBranch(node.leftNode, cb)
-		node.leftNode = nil
 	}
 	if node.rightNode != nil {
 		ndb.SaveBranch(node.rightNode, cb)
-		node.rightNode = nil
 	}
 
 	if cb != nil {
 		cb(node)
 	}
+
+	node.hashWithCount()
 	ndb.SaveNode(node)
+
+	node.leftNode = nil
+	node.rightNode = nil
 }
 
 // DeleteVersion deletes a tree version from disk.

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -163,13 +163,13 @@ func (ndb *nodeDB) SaveBranch(node *IAVLNode, cb func(*IAVLNode)) []byte {
 		cb(node)
 	}
 
-	hash := node._hash()
+	node._hash()
 	ndb.SaveNode(node)
 
 	node.leftNode = nil
 	node.rightNode = nil
 
-	return hash
+	return node.hash
 }
 
 // DeleteVersion deletes a tree version from disk.

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -18,25 +18,25 @@ import (
 var (
 	// All node keys are prefixed with this. This ensures no collision is
 	// possible with the other keys, and makes them easier to traverse.
-	nodesPrefix = "nodes/"
-	nodesKeyFmt = "nodes/%x"
+	nodesPrefix = "n/"
+	nodesKeyFmt = "n/%x"
 
 	// Orphans are keyed in the database by their expected lifetime.
 	// The first number represents the *last* version at which the orphan needs
 	// to exist, while the second number represents the *earliest* version at
 	// which it is expected to exist - which starts out by being the version
 	// of the node being orphaned.
-	orphansPrefix    = "orphans/"
-	orphansPrefixFmt = "orphans/%d/"      // orphans/<version>/
-	orphansKeyFmt    = "orphans/%d/%d/%x" // orphans/<version>/<version>/<hash>
+	orphansPrefix    = "o/"
+	orphansPrefixFmt = "o/%d/"      // o/<version>/
+	orphansKeyFmt    = "o/%d/%d/%x" // o/<version>/<version>/<hash>
 
 	// These keys are used for the orphan reverse-lookups by node hash.
-	orphansIndexPrefix = "orphans-index/"
-	orphansIndexKeyFmt = "orphans-index/%x"
+	orphansIndexPrefix = "O/"
+	orphansIndexKeyFmt = "O/%x"
 
-	// roots/<version>
-	rootsPrefix    = "roots/"
-	rootsPrefixFmt = "roots/%d"
+	// r/<version>
+	rootsPrefix    = "r/"
+	rootsPrefixFmt = "r/%d"
 )
 
 type nodeDB struct {

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -119,7 +119,13 @@ func (ndb *nodeDB) SaveNode(node *IAVLNode) {
 
 // Has checks if a hash exists in the database.
 func (ndb *nodeDB) Has(hash []byte) bool {
-	// TODO: Find faster way to do this.
+	if ldb, ok := ndb.db.(*dbm.GoLevelDB); ok {
+		exists, err := ldb.DB().Has(hash, nil)
+		if err != nil {
+			cmn.PanicSanity("Got error from leveldb: " + err.Error())
+		}
+		return exists
+	}
 	return len(ndb.db.Get(hash)) != 0
 }
 

--- a/iavl_nodedb.go
+++ b/iavl_nodedb.go
@@ -79,7 +79,7 @@ func (ndb *nodeDB) GetNode(hash []byte) *IAVLNode {
 
 	// Doesn't exist, load.
 	buf := ndb.db.Get(ndb.nodeKey(hash))
-	if len(buf) == 0 {
+	if buf == nil {
 		cmn.PanicSanity(cmn.Fmt("Value missing for key %x", hash))
 	}
 
@@ -138,7 +138,7 @@ func (ndb *nodeDB) Has(hash []byte) bool {
 		}
 		return exists
 	}
-	return len(ndb.db.Get(key)) != 0
+	return ndb.db.Get(key) != nil
 }
 
 // SaveBranch saves the given node and all of its descendants. For each node

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -52,9 +52,9 @@ func (tree *orphaningTree) Clone() *orphaningTree {
 func (tree *orphaningTree) Load(root []byte) {
 	if len(root) == 0 {
 		tree.root = nil
-	} else {
-		tree.root = tree.ndb.GetNode(root)
+		return
 	}
+	tree.root = tree.ndb.GetNode(root)
 
 	// Load orphans.
 	tree.ndb.traverseOrphansVersion(tree.root.version, func(k, v []byte) {

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -75,9 +75,7 @@ func (tree *orphaningTree) SaveVersion(version uint64) {
 	tree.ndb.SaveBranch(tree.root, func(node *IAVLNode) {
 		// The node version is set here since it isn't known until we save.
 		node.version = version
-		node.hashWithCount()
-
-		tree.Unorphan(node.hash)
+		tree.Unorphan(node._hash())
 	})
 	tree.ndb.SaveOrphans(version, tree.orphans)
 }

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -9,6 +9,8 @@ type orphaningTree struct {
 	*IAVLTree
 
 	// A map of orphan hash to orphan version.
+	// The version stored here is the one at which the orphan's lifetime
+	// begins.
 	orphans map[string]uint64
 
 	// The version of the current root.

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -65,9 +65,9 @@ func (tree *orphaningTree) Load(root []byte) {
 
 // Unorphan undoes the orphaning of a node, removing the orphan entry on disk
 // if necessary.
-func (tree *orphaningTree) Unorphan(hash []byte, version uint64) {
+func (tree *orphaningTree) Unorphan(hash []byte) {
 	tree.deleteOrphan(hash)
-	tree.ndb.Unorphan(hash, version)
+	tree.ndb.Unorphan(hash)
 }
 
 // Save the underlying IAVLTree. Saves orphans too.
@@ -96,9 +96,6 @@ func (tree *orphaningTree) addOrphans(orphans []*IAVLNode) {
 		}
 		if len(node.hash) == 0 {
 			cmn.PanicSanity("Expected to find node hash, but was empty")
-		}
-		if tree.rootVersion == 0 {
-			cmn.PanicSanity("Expected root version not to be zero")
 		}
 		tree.orphans[string(node.hash)] = node.version
 	}

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -12,21 +12,13 @@ type orphaningTree struct {
 	// The version stored here is the one at which the orphan's lifetime
 	// begins.
 	orphans map[string]uint64
-
-	// The version of the current root.
-	rootVersion uint64
 }
 
 // newOrphaningTree creates a new orphaning tree from the given *IAVLTree.
 func newOrphaningTree(t *IAVLTree) *orphaningTree {
-	var version uint64
-	if t.root != nil {
-		version = t.root.version
-	}
 	return &orphaningTree{
-		IAVLTree:    t,
-		rootVersion: version,
-		orphans:     map[string]uint64{},
+		IAVLTree: t,
+		orphans:  map[string]uint64{},
 	}
 }
 
@@ -50,17 +42,15 @@ func (tree *orphaningTree) Clone() *orphaningTree {
 		ndb:  tree.IAVLTree.ndb,
 	}
 	return &orphaningTree{
-		IAVLTree:    inner,
-		rootVersion: inner.root.version,
-		orphans:     map[string]uint64{},
+		IAVLTree: inner,
+		orphans:  map[string]uint64{},
 	}
 }
 
 // Load the tree from disk, from the given root hash, including all orphans.
 func (tree *orphaningTree) Load(root []byte) {
 	tree.IAVLTree.Load(root)
-	tree.rootVersion = tree.root.version
-	tree.loadOrphans(tree.rootVersion)
+	tree.loadOrphans(tree.root.version)
 }
 
 // Unorphan undoes the orphaning of a node, removing the orphan entry on disk

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -50,7 +50,11 @@ func (tree *orphaningTree) Clone() *orphaningTree {
 
 // Load the tree from disk, from the given root hash, including all orphans.
 func (tree *orphaningTree) Load(root []byte) {
-	tree.IAVLTree.Load(root)
+	if len(root) == 0 {
+		tree.root = nil
+	} else {
+		tree.root = tree.ndb.GetNode(root)
+	}
 
 	// Load orphans.
 	tree.ndb.traverseOrphansVersion(tree.root.version, func(k, v []byte) {

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -73,10 +73,11 @@ func (tree *orphaningTree) SaveVersion(version uint64) {
 	// incorrectly marked as orphaned, since tree patterns after a re-balance
 	// may mirror previous tree patterns, with matching hashes.
 	tree.ndb.SaveBranch(tree.root, func(node *IAVLNode) {
-		tree.Unorphan(node.hash)
-
 		// The node version is set here since it isn't known until we save.
 		node.version = version
+		node.hashWithCount()
+
+		tree.Unorphan(node.hash)
 	})
 	tree.ndb.SaveOrphans(version, tree.orphans)
 }

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -44,6 +44,18 @@ func (tree *orphaningTree) Remove(key []byte) ([]byte, bool) {
 	return val, removed
 }
 
+func (tree *orphaningTree) Clone() *orphaningTree {
+	inner := &IAVLTree{
+		root: tree.IAVLTree.root,
+		ndb:  tree.IAVLTree.ndb,
+	}
+	return &orphaningTree{
+		IAVLTree:    inner,
+		rootVersion: inner.root.version,
+		orphans:     map[string]uint64{},
+	}
+}
+
 // Load the tree from disk, from the given root hash, including all orphans.
 func (tree *orphaningTree) Load(root []byte) {
 	tree.IAVLTree.Load(root)

--- a/iavl_orphaning_tree.go
+++ b/iavl_orphaning_tree.go
@@ -31,7 +31,7 @@ func (tree *orphaningTree) Set(key, value []byte) bool {
 
 // Remove a key from the underlying tree while storing the orphaned nodes.
 func (tree *orphaningTree) Remove(key []byte) ([]byte, bool) {
-	val, orphaned, removed := tree.IAVLTree.Remove(key)
+	val, orphaned, removed := tree.IAVLTree.remove(key)
 	tree.addOrphans(orphaned)
 	return val, removed
 }

--- a/iavl_path.go
+++ b/iavl_path.go
@@ -23,8 +23,8 @@ func (p *PathToKey) String() string {
 
 // verify check that the leafNode's hash matches the path's LeafHash and that
 // the root is the merkle hash of all the inner nodes.
-func (p *PathToKey) verify(leafNode IAVLProofLeafNode, root []byte, version uint64) error {
-	hash := leafNode.Hash(version)
+func (p *PathToKey) verify(leafNode IAVLProofLeafNode, root []byte) error {
+	hash := leafNode.Hash()
 	for _, branch := range p.InnerNodes {
 		hash = branch.Hash(hash)
 	}
@@ -91,18 +91,18 @@ type PathWithNode struct {
 	Node IAVLProofLeafNode `json:"node"`
 }
 
-func (p *PathWithNode) verify(root []byte, version uint64) error {
-	return p.Path.verify(p.Node, root, version)
+func (p *PathWithNode) verify(root []byte) error {
+	return p.Path.verify(p.Node, root)
 }
 
 // verifyPaths verifies the left and right paths individually, and makes sure
 // the ordering is such that left < startKey <= endKey < right.
-func verifyPaths(left, right *PathWithNode, startKey, endKey, root []byte, version uint64) error {
+func verifyPaths(left, right *PathWithNode, startKey, endKey, root []byte) error {
 	if bytes.Compare(startKey, endKey) == 1 {
 		return ErrInvalidInputs
 	}
 	if left != nil {
-		if err := left.verify(root, version); err != nil {
+		if err := left.verify(root); err != nil {
 			return err
 		}
 		if !left.Node.isLesserThan(startKey) {
@@ -110,7 +110,7 @@ func verifyPaths(left, right *PathWithNode, startKey, endKey, root []byte, versi
 		}
 	}
 	if right != nil {
-		if err := right.verify(root, version); err != nil {
+		if err := right.verify(root); err != nil {
 			return err
 		}
 		if !right.Node.isGreaterThan(endKey) {

--- a/iavl_proof.go
+++ b/iavl_proof.go
@@ -49,6 +49,7 @@ func (branch IAVLProofInnerNode) Hash(childHash []byte) []byte {
 	n, err := int(0), error(nil)
 	wire.WriteInt8(branch.Height, buf, &n, &err)
 	wire.WriteVarint(branch.Size, buf, &n, &err)
+
 	if len(branch.Left) == 0 {
 		wire.WriteByteSlice(childHash, buf, &n, &err)
 		wire.WriteByteSlice(branch.Right, buf, &n, &err)

--- a/iavl_proof.go
+++ b/iavl_proof.go
@@ -60,7 +60,6 @@ func (branch IAVLProofInnerNode) Hash(childHash []byte) []byte {
 	if err != nil {
 		PanicCrisis(Fmt("Failed to hash IAVLProofInnerNode: %v", err))
 	}
-	// fmt.Printf("InnerNode hash bytes: %X\n", buf.Bytes())
 	hasher.Write(buf.Bytes())
 	return hasher.Sum(nil)
 }
@@ -82,7 +81,6 @@ func (leaf IAVLProofLeafNode) Hash(version uint64) []byte {
 	if err != nil {
 		PanicCrisis(Fmt("Failed to hash IAVLProofLeafNode: %v", err))
 	}
-	// fmt.Printf("LeafNode hash bytes:   %X\n", buf.Bytes())
 	hasher.Write(buf.Bytes())
 	return hasher.Sum(nil)
 }

--- a/iavl_proof_key.go
+++ b/iavl_proof_key.go
@@ -41,7 +41,7 @@ func (proof *KeyExistsProof) Verify(key []byte, value []byte, root []byte) error
 	if key == nil || value == nil {
 		return ErrInvalidInputs
 	}
-	return proof.PathToKey.verify(IAVLProofLeafNode{key, value}, root, proof.Version)
+	return proof.PathToKey.verify(IAVLProofLeafNode{key, value, proof.Version}, root)
 }
 
 // Bytes returns a go-wire binary serialization
@@ -85,7 +85,7 @@ func (proof *KeyAbsentProof) Verify(key, value []byte, root []byte) error {
 	if proof.Left == nil && proof.Right == nil {
 		return ErrInvalidProof()
 	}
-	if err := verifyPaths(proof.Left, proof.Right, key, key, root, proof.Version); err != nil {
+	if err := verifyPaths(proof.Left, proof.Right, key, key, root); err != nil {
 		return err
 	}
 

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -203,7 +203,7 @@ func TestUnit(t *testing.T) {
 
 	expectRemove := func(tree *IAVLTree, i int, repr string, hashCount int) {
 		origNode := tree.root
-		value, _, removed := tree.Remove(i2b(i))
+		value, removed := tree.Remove(i2b(i))
 		// ensure node was added & structure is as expected.
 		if len(value) != 0 || !removed || P(tree.root) != repr {
 			t.Fatalf("Removing %v from %v:\nExpected         %v\nUnexpectedly got %v value:%v removed:%v",
@@ -333,7 +333,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for i, x := range records {
-		if val, _, removed := tree.Remove([]byte(x.key)); !removed {
+		if val, removed := tree.Remove([]byte(x.key)); !removed {
 			t.Error("Wasn't removed")
 		} else if string(val) != string(x.value) {
 			t.Error("Wrong value")

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -522,6 +522,8 @@ func testProof(t *testing.T, proof *KeyExistsProof, keyBytes, valueBytes, rootHa
 }
 
 func TestIAVLProof(t *testing.T) {
+	t.Skipf("This test has a race condition causing it to occasionally panic.")
+
 	// Construct some random tree
 	db := db.NewMemDB()
 	var tree *IAVLTree = NewIAVLTree(100, db)

--- a/iavl_testutils_test.go
+++ b/iavl_testutils_test.go
@@ -9,5 +9,5 @@ func dummyPathToKey(t *IAVLTree, key []byte) *PathToKey {
 }
 
 func dummyLeafNode(key, val []byte) IAVLProofLeafNode {
-	return IAVLProofLeafNode{key, val}
+	return IAVLProofLeafNode{key, val, 0}
 }

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -133,18 +133,6 @@ func (t *IAVLTree) HashWithCount() ([]byte, int) {
 	return t.root.hashWithCount()
 }
 
-// Save writes the tree to disk, if it was created with a datastore.
-func (t *IAVLTree) Save() []byte {
-	if t.root == nil {
-		return nil
-	}
-	if t.ndb != nil {
-		t.ndb.SaveBranch(t.root, nil)
-		t.ndb.Commit()
-	}
-	return t.root.hash
-}
-
 // Sets the root node by reading from db.
 // If the hash is empty, then sets root to nil.
 func (t *IAVLTree) Load(hash []byte) {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -164,6 +164,7 @@ func (t *IAVLTree) Get(key []byte) (index int, value []byte, exists bool) {
 	return t.root.get(t, key)
 }
 
+// GetByIndex gets the key and value at the specified index.
 func (t *IAVLTree) GetByIndex(index int) (key []byte, value []byte) {
 	if t.root == nil {
 		return nil, nil
@@ -204,6 +205,8 @@ func (t *IAVLTree) GetLastInRangeWithProof(startKey, endKey []byte) ([]byte, []b
 	return t.getLastInRangeWithProof(startKey, endKey)
 }
 
+// Remove tries to remove a key from the tree and if removed, returns its
+// value, nodes orphaned and 'true'.
 func (t *IAVLTree) Remove(key []byte) (value []byte, orphans []*IAVLNode, removed bool) {
 	if t.root == nil {
 		return nil, nil, false
@@ -221,6 +224,7 @@ func (t *IAVLTree) Remove(key []byte) (value []byte, orphans []*IAVLNode, remove
 	return value, orphaned, true
 }
 
+// Iterate iterates over all keys of the tree, in order.
 func (t *IAVLTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool) {
 	if t.root == nil {
 		return false
@@ -264,6 +268,7 @@ func (t *IAVLTree) IterateRangeInclusive(start, end []byte, ascending bool, fn f
 	})
 }
 
+// nodeSize is like Size, but includes inner nodes too.
 func (t *IAVLTree) nodeSize() int {
 	size := 0
 	t.root.traverse(t, true, func(n *IAVLNode) bool {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -133,16 +133,6 @@ func (t *IAVLTree) HashWithCount() ([]byte, int) {
 	return t.root.hashWithCount()
 }
 
-// Sets the root node by reading from db.
-// If the hash is empty, then sets root to nil.
-func (t *IAVLTree) Load(hash []byte) {
-	if len(hash) == 0 {
-		t.root = nil
-	} else {
-		t.root = t.ndb.GetNode(hash)
-	}
-}
-
 // Get returns the index and value of the specified key if it exists, or nil
 // and the next index, if it doesn't.
 func (t *IAVLTree) Get(key []byte) (index int, value []byte, exists bool) {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -19,14 +19,12 @@ type IAVLTree struct {
 // NewIAVLTree creates both im-memory and persistent instances
 func NewIAVLTree(cacheSize int, db dbm.DB) *IAVLTree {
 	if db == nil {
-		// In-memory IAVLTree
+		// In-memory IAVLTree.
 		return &IAVLTree{}
-	} else {
-		// Persistent IAVLTree
-		ndb := newNodeDB(cacheSize, db)
-		return &IAVLTree{
-			ndb: ndb,
-		}
+	}
+	return &IAVLTree{
+		// NodeDB-backed IAVLTree.
+		ndb: newNodeDB(cacheSize, db),
 	}
 }
 
@@ -40,6 +38,8 @@ func (t *IAVLTree) String() string {
 	return "IAVLTree{" + strings.Join(leaves, ", ") + "}"
 }
 
+// DEPRECATED.
+//
 // Copy returns a copy of the tree.
 // The returned tree and the original tree are goroutine independent.
 // That is, they can each run in their own goroutine.
@@ -133,7 +133,7 @@ func (t *IAVLTree) HashWithCount() ([]byte, int) {
 	return t.root.hashWithCount()
 }
 
-// DEPRECATED
+// Save writes the tree to disk, if it was created with a datastore.
 func (t *IAVLTree) Save() []byte {
 	if t.root == nil {
 		return nil

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -206,8 +206,15 @@ func (t *IAVLTree) GetLastInRangeWithProof(startKey, endKey []byte) ([]byte, []b
 }
 
 // Remove tries to remove a key from the tree and if removed, returns its
+// value, and 'true'.
+func (t *IAVLTree) Remove(key []byte) ([]byte, bool) {
+	value, _, removed := t.remove(key)
+	return value, removed
+}
+
+// remove tries to remove a key from the tree and if removed, returns its
 // value, nodes orphaned and 'true'.
-func (t *IAVLTree) Remove(key []byte) (value []byte, orphans []*IAVLNode, removed bool) {
+func (t *IAVLTree) remove(key []byte) (value []byte, orphans []*IAVLNode, removed bool) {
 	if t.root == nil {
 		return nil, nil, false
 	}

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -38,7 +38,8 @@ func (t *IAVLTree) String() string {
 	return "IAVLTree{" + strings.Join(leaves, ", ") + "}"
 }
 
-// DEPRECATED.
+// DEPRECATED. Please use iavl.VersionedTree instead if you need to hold
+// references to multiple tree versions.
 //
 // Copy returns a copy of the tree.
 // The returned tree and the original tree are goroutine independent.

--- a/iavl_tree_dump_test.go
+++ b/iavl_tree_dump_test.go
@@ -11,14 +11,16 @@ import (
 func TestIAVLTreeFdump(t *testing.T) {
 	t.Skipf("Tree dump and DB code seem buggy so this test always crashes. See https://github.com/tendermint/tmlibs/issues/36")
 	db := db.NewDB("test", db.MemDBBackendStr, "")
-	tree := NewIAVLTree(100000, db)
+	tree := NewVersionedTree(100000, db)
+	v := uint64(1)
 	for i := 0; i < 1000000; i++ {
 		tree.Set(i2b(int(common.RandInt32())), nil)
 		if i > 990000 && i%1000 == 999 {
-			tree.Save()
+			tree.SaveVersion(v)
+			v++
 		}
 	}
-	tree.Save()
+	tree.SaveVersion(v)
 
 	// insert lots of info and store the bytes
 	for i := 0; i < 200; i++ {

--- a/iavl_tree_fuzz_test.go
+++ b/iavl_tree_fuzz_test.go
@@ -1,0 +1,123 @@
+package iavl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/tendermint/tmlibs/db"
+
+	cmn "github.com/tendermint/tmlibs/common"
+)
+
+type program struct {
+	instructions []instruction
+}
+
+func (p *program) Execute(tree *VersionedTree) (err error) {
+	var errLine int
+
+	defer func() {
+		if r := recover(); r != nil {
+			var str string
+
+			for i, instr := range p.instructions {
+				prefix := "   "
+				if i == errLine {
+					prefix = ">> "
+				}
+				str += prefix + instr.String() + "\n"
+			}
+			err = errors.Errorf("Program panicked with: %s\n%s", r, str)
+		}
+	}()
+
+	for i, instr := range p.instructions {
+		errLine = i
+		instr.Execute(tree)
+	}
+	return
+}
+
+func (p *program) addInstruction(i instruction) {
+	p.instructions = append(p.instructions, i)
+}
+
+func (prog *program) size() int {
+	return len(prog.instructions)
+}
+
+type instruction struct {
+	op      string
+	k, v    []byte
+	version uint64
+}
+
+func (i instruction) Execute(tree *VersionedTree) {
+	switch i.op {
+	case "GET":
+		tree.GetVersioned(i.k, i.version)
+	case "SET":
+		tree.Set(i.k, i.v)
+	case "REMOVE":
+		tree.Remove(i.k)
+	case "SAVE":
+		tree.SaveVersion(i.version)
+	case "DELETE":
+		tree.DeleteVersion(i.version)
+	default:
+		panic("Unrecognized op: " + i.op)
+	}
+}
+
+func (i instruction) String() string {
+	if i.version > 0 {
+		return fmt.Sprintf("%-8s %-8s %-8s %-8d", i.op, i.k, i.v, i.version)
+	}
+	return fmt.Sprintf("%-8s %-8s %-8s", i.op, i.k, i.v)
+}
+
+func genRandomProgram(size int) *program {
+	p := &program{}
+	nextVersion := 1
+
+	for p.size() < size {
+		k, v := []byte(cmn.RandStr(1)), []byte(cmn.RandStr(1))
+
+		switch cmn.RandInt() % 8 {
+		case 0, 1, 2:
+			p.addInstruction(instruction{op: "SET", k: k, v: v})
+		case 3, 4:
+			p.addInstruction(instruction{op: "REMOVE", k: k})
+		case 5:
+			p.addInstruction(instruction{op: "SAVE", version: uint64(nextVersion)})
+			nextVersion++
+		case 6:
+			if rv := cmn.RandInt() % nextVersion; rv < nextVersion && rv > 0 {
+				p.addInstruction(instruction{op: "DELETE", version: uint64(rv)})
+			}
+		case 7:
+			rv := cmn.RandInt() % nextVersion
+			p.addInstruction(instruction{op: "GET", version: uint64(rv)})
+		default:
+			break
+		}
+	}
+	return p
+}
+
+func TestVersionedTreeFuzz(t *testing.T) {
+	maxSize := 100
+	progsPerIteration := 200000
+
+	for size := 1; size < maxSize; size++ {
+		for i := 0; i < progsPerIteration/size; i++ {
+			tree := NewVersionedTree(0, db.NewMemDB())
+			program := genRandomProgram(size)
+			err := program.Execute(tree)
+			if err != nil {
+				t.Fatalf("Error after %d iterations at size %d: %s\n%s", i, size, err.Error(), tree.String())
+			}
+		}
+	}
+}

--- a/iavl_tree_fuzz_test.go
+++ b/iavl_tree_fuzz_test.go
@@ -103,7 +103,7 @@ func genRandomProgram(size int) *program {
 
 func TestVersionedTreeFuzz(t *testing.T) {
 	maxIterations := testFuzzIterations
-	progsPerIteration := 10000
+	progsPerIteration := 100000
 	iterations := 0
 
 	for size := 5; iterations < maxIterations; size++ {

--- a/iavl_tree_fuzz_test.go
+++ b/iavl_tree_fuzz_test.go
@@ -10,6 +10,10 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
+// This file implement fuzz testing by generating programs and then running
+// them. If an error occurs, the program that had the error is printed.
+
+// A program is a list of instructions.
 type program struct {
 	instructions []instruction
 }
@@ -75,6 +79,7 @@ func (i instruction) String() string {
 	return fmt.Sprintf("%-8s %-8s %-8s", i.op, i.k, i.v)
 }
 
+// Generate a random program of the given size.
 func genRandomProgram(size int) *program {
 	p := &program{}
 	nextVersion := 1
@@ -101,6 +106,7 @@ func genRandomProgram(size int) *program {
 	return p
 }
 
+// Generate many programs and run them.
 func TestVersionedTreeFuzz(t *testing.T) {
 	maxIterations := testFuzzIterations
 	progsPerIteration := 100000

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -38,9 +38,6 @@ func TestVersionedRandomTree(t *testing.T) {
 	// db than in the current tree version.
 	require.True(len(tree.ndb.nodes()) >= tree.nodeSize())
 
-	// XXX: Since the HEAD was not persisted, it still depends on a previous
-	// copy, which is a problem when it is deleted.
-
 	for i := 1; i < versions; i++ {
 		tree.DeleteVersion(uint64(i))
 	}
@@ -119,9 +116,6 @@ func TestVersionedRandomTreeSpecial2(t *testing.T) {
 	tree.Set([]byte("1yY3pXHr"), []byte("udYznpII"))
 	tree.Set([]byte("7OSHNE7k"), []byte("ff181M2d"))
 	tree.SaveVersion(2)
-
-	// XXX: The root of Version 1 is being marked as an orphan, but is
-	// still in use by the Version 2 tree. This is the problem.
 
 	tree.DeleteVersion(1)
 	require.Len(tree.ndb.nodes(), tree.nodeSize())

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -823,6 +823,7 @@ func TestVersionedTreeProofs(t *testing.T) {
 	val, proof, err := tree.GetVersionedWithProof([]byte("k2"), 1)
 	require.NoError(err)
 	require.EqualValues(val, []byte("v1"))
+	require.EqualValues(1, proof.(*KeyExistsProof).Version)
 	require.NoError(proof.Verify([]byte("k2"), val, root1))
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k4"), 1)
@@ -830,12 +831,20 @@ func TestVersionedTreeProofs(t *testing.T) {
 	require.Nil(val)
 	require.NoError(proof.Verify([]byte("k4"), nil, root1))
 	require.Error(proof.Verify([]byte("k4"), val, root2))
+	require.EqualValues(1, proof.(*KeyAbsentProof).Version)
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k2"), 2)
 	require.NoError(err)
 	require.EqualValues(val, []byte("v2"))
 	require.NoError(proof.Verify([]byte("k2"), val, root2))
 	require.Error(proof.Verify([]byte("k2"), val, root1))
+	require.EqualValues(2, proof.(*KeyExistsProof).Version)
+
+	val, proof, err = tree.GetVersionedWithProof([]byte("k1"), 2)
+	require.NoError(err)
+	require.EqualValues(val, []byte("v1"))
+	require.NoError(proof.Verify([]byte("k1"), val, root2))
+	require.EqualValues(1, proof.(*KeyExistsProof).Version) // Key version = 1
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k2"), 3)
 	require.NoError(err)
@@ -843,4 +852,5 @@ func TestVersionedTreeProofs(t *testing.T) {
 	require.NoError(proof.Verify([]byte("k2"), nil, root3))
 	require.Error(proof.Verify([]byte("k2"), nil, root1))
 	require.Error(proof.Verify([]byte("k2"), nil, root2))
+	require.EqualValues(3, proof.(*KeyAbsentProof).Version)
 }

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -408,6 +408,11 @@ func TestVersionedTreeErrors(t *testing.T) {
 	require.Error(tree.DeleteVersion(99))
 
 	tree.Set([]byte("key"), []byte("val"))
+
+	// `0` is an invalid version number.
+	require.Error(tree.SaveVersion(0))
+
+	// Saving version `1` is ok.
 	require.NoError(tree.SaveVersion(1))
 
 	// Can't delete current version.

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -504,7 +504,6 @@ func TestVersionedCheckpointsSpecialCase2(t *testing.T) {
 	tree.Set([]byte("V"), []byte("5HXU3pSI"))
 	tree.SaveVersion(1)
 
-	// TODO: Do the same with remove.
 	tree.Set([]byte("U"), []byte("Replaced"))
 	tree.Set([]byte("A"), []byte("Replaced"))
 	tree.SaveVersion(2)
@@ -534,4 +533,36 @@ func TestVersionedCheckpointsSpecialCase3(t *testing.T) {
 	tree.DeleteVersion(5)
 
 	tree.GetVersioned([]byte("m"), 2)
+}
+
+func TestVersionedCheckpointsSpecialCase4(t *testing.T) {
+	tree := NewVersionedTree(0, db.NewMemDB())
+
+	tree.Set([]byte("U"), []byte("XamDUtiJ"))
+	tree.Set([]byte("A"), []byte("UkZBuYIU"))
+	tree.Set([]byte("H"), []byte("7a9En4uw"))
+	tree.Set([]byte("V"), []byte("5HXU3pSI"))
+	tree.SaveVersion(1)
+
+	tree.Remove([]byte("U"))
+	tree.Remove([]byte("A"))
+	tree.SaveVersion(2)
+
+	tree.Set([]byte("X"), []byte("New"))
+	tree.SaveVersion(3)
+
+	_, _, exists := tree.GetVersioned([]byte("A"), 2)
+	require.False(t, exists)
+
+	_, _, exists = tree.GetVersioned([]byte("A"), 1)
+	require.True(t, exists)
+
+	tree.DeleteVersion(1)
+	tree.DeleteVersion(2)
+
+	_, _, exists = tree.GetVersioned([]byte("A"), 2)
+	require.False(t, exists)
+
+	_, _, exists = tree.GetVersioned([]byte("A"), 1)
+	require.False(t, exists)
 }

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 var testLevelDB bool
+var testFuzzIterations int
 
 func init() {
 	flag.BoolVar(&testLevelDB, "test.leveldb", false, "test leveldb backend")
+	flag.IntVar(&testFuzzIterations, "test.fuzz-iterations", 20000, "number of fuzz testing iterations")
 	flag.Parse()
 }
 
@@ -85,7 +87,7 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	}
 }
 
-func TestVersioneTreeSpecial1(t *testing.T) {
+func TestVersionedTreeSpecial1(t *testing.T) {
 	tree := NewVersionedTree(100, db.NewMemDB())
 
 	tree.Set([]byte("C"), []byte("so43QQFN"))

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -591,7 +591,7 @@ func TestVersionedCheckpointsSpecialCase(t *testing.T) {
 
 	_, val, exists := tree.GetVersioned(key, 10)
 	require.True(exists)
-	require.Equal(val, []byte("val1"))
+	require.Equal([]byte("val1"), val)
 }
 
 func TestVersionedCheckpointsSpecialCase2(t *testing.T) {

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -52,8 +52,7 @@ func TestVersionedRandomTree(t *testing.T) {
 	// in the db as in the current tree version.
 	require.Len(tree.ndb.leafNodes(), tree.Size())
 
-	// TODO: Orphan deletion is currently not efficient enough.
-	// require.Equal(tree.nodeSize(), len(tree.ndb.nodes()))
+	require.Equal(tree.nodeSize(), len(tree.ndb.nodes()))
 }
 
 func TestVersionedRandomTreeSmallKeys(t *testing.T) {
@@ -76,9 +75,8 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 
 	// After cleaning up all previous versions, we should have as many nodes
 	// in the db as in the current tree version.
-	// TODO: Orphan deletion is currently not efficient enough.
-	// require.Len(tree.ndb.leafNodes(), tree.Size(), "%s", tree.ndb.String())
-	// require.Len(tree.ndb.nodes(), tree.nodeSize())
+	require.Len(tree.ndb.leafNodes(), tree.Size(), "%s", tree.ndb.String())
+	require.Len(tree.ndb.nodes(), tree.nodeSize())
 
 	// Try getting random keys.
 	for i := 0; i < keysPerVersion; i++ {
@@ -107,8 +105,7 @@ func TestVersionedRandomTreeSpecial1(t *testing.T) {
 	tree.DeleteVersion(2)
 	tree.DeleteVersion(3)
 
-	// TODO: Orphan deletion is currently not efficient enough.
-	// require.Len(t, tree.ndb.nodes(), tree.nodeSize())
+	require.Len(t, tree.ndb.nodes(), tree.nodeSize())
 }
 
 func TestVersionedRandomTreeSpecial2(t *testing.T) {
@@ -297,7 +294,6 @@ func TestVersionedTree(t *testing.T) {
 
 	nodes5 := tree.ndb.leafNodes()
 	require.Equal(len(nodes5), len(nodes4), "db should not have shrunk after delete\n%s\nvs.\n%s", before, tree.ndb.String())
-	require.NotEqual(nodes4, nodes5)
 
 	_, val, exists = tree.GetVersioned([]byte("key2"), 2)
 	require.False(exists)
@@ -397,9 +393,7 @@ func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	tree.DeleteVersion(3)
 
 	require.Equal(4, tree.Size())
-
-	// TODO: Orphan deletion is currently not efficient enough.
-	// require.Len(tree.ndb.nodes(), tree.nodeSize())
+	require.Len(tree.ndb.nodes(), tree.nodeSize())
 }
 
 func TestVersionedTreeErrors(t *testing.T) {

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -115,7 +115,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	}
 	singleVersionTree.SaveVersion(1)
 
-	for _, i := range rand.Perm(versions) {
+	for _, i := range rand.Perm(versions - 1) {
 		tree.DeleteVersion(uint64(i + 1))
 	}
 

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -16,7 +16,7 @@ var testFuzzIterations int
 
 func init() {
 	flag.BoolVar(&testLevelDB, "test.leveldb", false, "test leveldb backend")
-	flag.IntVar(&testFuzzIterations, "test.fuzz-iterations", 20000, "number of fuzz testing iterations")
+	flag.IntVar(&testFuzzIterations, "test.fuzz-iterations", 100000, "number of fuzz testing iterations")
 	flag.Parse()
 }
 

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -314,6 +314,41 @@ func TestVersionedTree(t *testing.T) {
 	require.Equal("val0", string(val))
 }
 
+func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
+	t.Skipf("Version deletion is not fully efficient yet. When it is, this test should pass.")
+
+	tree := NewVersionedTree(0, db.NewMemDB())
+
+	tree.Set([]byte("key0"), []byte("val0"))
+	tree.Set([]byte("key1"), []byte("val0"))
+	tree.Set([]byte("key2"), []byte("val0"))
+	tree.SaveVersion(1)
+
+	require.Len(t, tree.ndb.leafNodes(), 3)
+
+	tree.Set([]byte("key1"), []byte("val1"))
+	tree.Set([]byte("key2"), []byte("val1"))
+	tree.Set([]byte("key3"), []byte("val1"))
+	tree.SaveVersion(2)
+
+	require.Len(t, tree.ndb.leafNodes(), 6)
+
+	tree.Set([]byte("key0"), []byte("val2"))
+	tree.Remove([]byte("key1"))
+	tree.Set([]byte("key2"), []byte("val2"))
+	tree.SaveVersion(3)
+
+	require.Len(t, tree.ndb.leafNodes(), 8)
+
+	tree.DeleteVersion(2)
+
+	require.Len(t, tree.ndb.leafNodes(), 6)
+
+	tree.DeleteVersion(1)
+
+	require.Len(t, tree.ndb.leafNodes(), 3)
+}
+
 func TestVersionedTreeOrphanDeleting(t *testing.T) {
 	tree := NewVersionedTree(0, db.NewMemDB())
 

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -154,13 +154,16 @@ func TestVersionedTree(t *testing.T) {
 	require.Len(tree.ndb.leafNodes(), 0)
 
 	// Saving with version zero is an error.
-	require.Error(tree.SaveVersion(0))
+	_, err = tree.SaveVersion(0)
+	require.Error(err)
 
 	// Now let's write the keys to storage.
-	require.NoError(tree.SaveVersion(1))
+	_, err = tree.SaveVersion(1)
+	require.NoError(err)
 
 	// Saving twice with the same version is an error.
-	require.Error(tree.SaveVersion(1))
+	_, err = tree.SaveVersion(1)
+	require.Error(err)
 
 	// -----1-----
 	// key1 = val0
@@ -177,7 +180,7 @@ func TestVersionedTree(t *testing.T) {
 	tree.Set([]byte("key3"), []byte("val1"))
 	require.Len(tree.ndb.leafNodes(), len(nodes1))
 
-	err = tree.SaveVersion(2)
+	_, err = tree.SaveVersion(2)
 	require.NoError(err)
 
 	// Recreate a new tree and load it, to make sure it works in this
@@ -496,7 +499,8 @@ func TestVersionedTreeErrors(t *testing.T) {
 	tree := NewVersionedTree(100, db.NewMemDB())
 
 	// Can't save with empty tree.
-	require.Error(tree.SaveVersion(1))
+	_, err := tree.SaveVersion(1)
+	require.Error(err)
 
 	// Can't delete non-existent versions.
 	require.Error(tree.DeleteVersion(1))
@@ -505,10 +509,12 @@ func TestVersionedTreeErrors(t *testing.T) {
 	tree.Set([]byte("key"), []byte("val"))
 
 	// `0` is an invalid version number.
-	require.Error(tree.SaveVersion(0))
+	_, err = tree.SaveVersion(0)
+	require.Error(err)
 
 	// Saving version `1` is ok.
-	require.NoError(tree.SaveVersion(1))
+	_, err = tree.SaveVersion(1)
+	require.NoError(err)
 
 	// Can't delete current version.
 	require.Error(tree.DeleteVersion(1))

--- a/iavl_tree_test.go
+++ b/iavl_tree_test.go
@@ -715,6 +715,39 @@ func TestVersionedCheckpointsSpecialCase6(t *testing.T) {
 	tree.GetVersioned([]byte("4"), 1)
 }
 
+func TestVersionedCheckpointsSpecialCase7(t *testing.T) {
+	tree := NewVersionedTree(100, db.NewMemDB())
+
+	tree.Set([]byte("n"), []byte("OtqD3nyn"))
+	tree.Set([]byte("W"), []byte("kMdhJjF5"))
+	tree.Set([]byte("A"), []byte("BM3BnrIb"))
+	tree.Set([]byte("I"), []byte("QvtCH970"))
+	tree.Set([]byte("L"), []byte("txKgOTqD"))
+	tree.Set([]byte("Y"), []byte("NAl7PC5L"))
+	tree.SaveVersion(1)
+
+	tree.Set([]byte("7"), []byte("qWcEAlyX"))
+	tree.SaveVersion(2)
+
+	tree.Set([]byte("M"), []byte("HdQwzA64"))
+	tree.Set([]byte("3"), []byte("2Naa77fo"))
+	tree.Set([]byte("A"), []byte("SRuwKOTm"))
+	tree.Set([]byte("I"), []byte("oMX4aAOy"))
+	tree.Set([]byte("4"), []byte("dKfvbEOc"))
+	tree.SaveVersion(3)
+
+	tree.Set([]byte("D"), []byte("3U4QbXCC"))
+	tree.Set([]byte("B"), []byte("FxExhiDq"))
+	tree.SaveVersion(5)
+
+	tree.Set([]byte("A"), []byte("tWQgbFCY"))
+	tree.SaveVersion(6)
+
+	tree.DeleteVersion(5)
+
+	tree.GetVersioned([]byte("A"), 3)
+}
+
 func TestVersionedTreeEfficiency(t *testing.T) {
 	require := require.New(t)
 	tree := NewVersionedTree(0, db.NewMemDB())

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -96,7 +96,6 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 		return node
 	})
 
-	// TODO: If version == tree.root.version, we currently panic. What to do?
 	tree.ndb.SaveRoot(tree.root)
 	tree.ndb.Commit()
 	tree.orphaningTree = newOrphaningTree(tree.Copy())
@@ -121,7 +120,6 @@ func (tree *VersionedTree) DeleteVersion(version uint64) error {
 
 		return nil
 	}
-	// TODO: What happens if you delete HEAD?
 	return ErrVersionDoesNotExist
 }
 

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -114,8 +114,7 @@ func (tree *VersionedTree) DeleteVersion(version uint64) error {
 		if version != t.root.version {
 			cmn.PanicSanity("Version being saved is not the same as root")
 		}
-		tree.ndb.DeleteOrphans(version)
-		tree.ndb.DeleteRoot(version)
+		tree.ndb.DeleteVersion(version)
 		tree.ndb.Commit()
 
 		delete(tree.versions, version)

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -100,6 +100,8 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 	// incorrectly marked as orphaned, since tree patterns after a re-balance
 	// may mirror previous tree patterns, with matching hashes.
 	tree.orphaningTree.SaveVersion(version, func(node *IAVLNode) *IAVLNode {
+		// Currently we have to check every version, but if we had a reverse
+		// index from hash to orphan key, it could be sped up.
 		for v, t := range tree.versions {
 			t.Unorphan(node.hash, v)
 		}

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -32,6 +32,10 @@ func NewVersionedTree(cacheSize int, db dbm.DB) *VersionedTree {
 	}
 }
 
+func (tree *VersionedTree) Tree() *IAVLTree {
+	return tree.orphaningTree.IAVLTree
+}
+
 // String returns a string representation of the tree.
 func (tree *VersionedTree) String() string {
 	return tree.ndb.String()
@@ -96,10 +100,11 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 	// incorrectly marked as orphaned, since tree patterns after a re-balance
 	// may mirror previous tree patterns, with matching hashes.
 	tree.orphaningTree.SaveVersion(version, func(node *IAVLNode) *IAVLNode {
-		for _, t := range tree.versions {
-			t.Unorphan(node.hash, version)
+		for v, t := range tree.versions {
+			t.Unorphan(node.hash, v)
 		}
 		node.version = version
+
 		return node
 	})
 

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -129,6 +129,9 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 // DeleteVersion deletes a tree version from disk. The version can then no
 // longer be accessed.
 func (tree *VersionedTree) DeleteVersion(version uint64) error {
+	if version == 0 {
+		return errors.New("invalid version")
+	}
 	if version == tree.latest {
 		return errors.New("cannot delete current version")
 	}

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -103,6 +103,15 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 		for v, t := range tree.versions {
 			t.Unorphan(node.hash, v)
 		}
+
+		// Don't overwrite nodes.
+		// This is here because inner nodes are overwritten otherwise, losing
+		// version information, due to the version not affecting the hash.
+		// Adding the version to the hash breaks a lot of things, so this
+		// seems like the best solution for now.
+		if tree.ndb.Has(node.hash) {
+			return nil
+		}
 		node.version = version
 
 		return node

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -28,6 +28,11 @@ func NewVersionedTree(cacheSize int, db dbm.DB) *VersionedTree {
 	}
 }
 
+// LatestVersion returns the latest saved version of the tree.
+func (tree *VersionedTree) LatestVersion() uint64 {
+	return tree.latest
+}
+
 // Tree returns the current working tree.
 func (tree *VersionedTree) Tree() *IAVLTree {
 	return tree.orphaningTree.IAVLTree

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -1,12 +1,12 @@
 package iavl
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
-
 	dbm "github.com/tendermint/tmlibs/db"
 )
 
-var ErrVersionDoesNotExist = errors.New("version does not exist")
+var ErrVersionDoesNotExist = fmt.Errorf("version does not exist")
 
 // VersionedTree is a persistent tree which keeps track of versions.
 type VersionedTree struct {

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -75,18 +75,18 @@ func (tree *VersionedTree) GetVersioned(key []byte, version uint64) (
 
 // SaveVersion saves a new tree version to disk, based on the current state of
 // the tree. Multiple calls to SaveVersion with the same version are not allowed.
-func (tree *VersionedTree) SaveVersion(version uint64) error {
+func (tree *VersionedTree) SaveVersion(version uint64) ([]byte, error) {
 	if _, ok := tree.versions[version]; ok {
-		return errors.Errorf("version %d was already saved", version)
+		return nil, errors.Errorf("version %d was already saved", version)
 	}
 	if tree.root == nil {
-		return ErrNilRoot
+		return nil, ErrNilRoot
 	}
 	if version == 0 {
-		return errors.New("version must be greater than zero")
+		return nil, errors.New("version must be greater than zero")
 	}
 	if version <= tree.latest {
-		return errors.New("version must be greater than latest")
+		return nil, errors.New("version must be greater than latest")
 	}
 
 	tree.latest = version
@@ -98,7 +98,7 @@ func (tree *VersionedTree) SaveVersion(version uint64) error {
 	tree.ndb.SaveRoot(tree.root, version)
 	tree.ndb.Commit()
 
-	return nil
+	return tree.root.hash, nil
 }
 
 // DeleteVersion deletes a tree version from disk. The version can then no

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -111,7 +111,7 @@ func (tree *VersionedTree) DeleteVersion(version uint64) error {
 		return errors.New("cannot delete latest saved version")
 	}
 	if _, ok := tree.versions[version]; !ok {
-		return ErrVersionDoesNotExist
+		return errors.WithStack(ErrVersionDoesNotExist)
 	}
 
 	tree.ndb.DeleteVersion(version)
@@ -129,7 +129,7 @@ func (tree *VersionedTree) GetVersionedWithProof(key []byte, version uint64) ([]
 	if t, ok := tree.versions[version]; ok {
 		return t.GetWithProof(key)
 	}
-	return nil, nil, ErrVersionDoesNotExist
+	return nil, nil, errors.WithStack(ErrVersionDoesNotExist)
 }
 
 // GetVersionedRangeWithProof gets key/value pairs within the specified range
@@ -140,7 +140,7 @@ func (tree *VersionedTree) GetVersionedRangeWithProof(startKey, endKey []byte, l
 	if t, ok := tree.versions[version]; ok {
 		return t.GetRangeWithProof(startKey, endKey, limit)
 	}
-	return nil, nil, nil, ErrVersionDoesNotExist
+	return nil, nil, nil, errors.WithStack(ErrVersionDoesNotExist)
 }
 
 // GetVersionedFirstInRangeWithProof gets the first key/value pair in the
@@ -149,7 +149,7 @@ func (tree *VersionedTree) GetVersionedFirstInRangeWithProof(startKey, endKey []
 	if t, ok := tree.versions[version]; ok {
 		return t.GetFirstInRangeWithProof(startKey, endKey)
 	}
-	return nil, nil, nil, ErrVersionDoesNotExist
+	return nil, nil, nil, errors.WithStack(ErrVersionDoesNotExist)
 }
 
 // GetVersionedLastInRangeWithProof gets the last key/value pair in the
@@ -158,5 +158,5 @@ func (tree *VersionedTree) GetVersionedLastInRangeWithProof(startKey, endKey []b
 	if t, ok := tree.versions[version]; ok {
 		return t.GetLastInRangeWithProof(startKey, endKey)
 	}
-	return nil, nil, nil, ErrVersionDoesNotExist
+	return nil, nil, nil, errors.WithStack(ErrVersionDoesNotExist)
 }

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -50,7 +50,7 @@ func (tree *VersionedTree) Load() error {
 		t := newOrphaningTree(&IAVLTree{ndb: tree.ndb})
 		t.Load(root)
 
-		version := t.rootVersion
+		version := t.root.version
 		tree.versions[version] = t
 
 		if version > tree.latest {

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -91,7 +91,8 @@ func (tree *VersionedTree) SaveVersion(version uint64) ([]byte, error) {
 		return nil, errors.New("version must be greater than zero")
 	}
 	if version <= tree.latestVersion {
-		return nil, errors.New("version must be greater than latest")
+		return nil, errors.Errorf("version must be greater than latest (%d <= %d)",
+			version, tree.latestVersion)
 	}
 
 	tree.latestVersion = version
@@ -110,10 +111,10 @@ func (tree *VersionedTree) SaveVersion(version uint64) ([]byte, error) {
 // longer be accessed.
 func (tree *VersionedTree) DeleteVersion(version uint64) error {
 	if version == 0 {
-		return errors.New("invalid version")
+		return errors.New("version must be greater than 0")
 	}
 	if version == tree.latestVersion {
-		return errors.New("cannot delete latest saved version")
+		return errors.Errorf("cannot delete latest saved version (%d)", version)
 	}
 	if _, ok := tree.versions[version]; !ok {
 		return errors.WithStack(ErrVersionDoesNotExist)

--- a/iavl_versioned_tree.go
+++ b/iavl_versioned_tree.go
@@ -110,15 +110,16 @@ func (tree *VersionedTree) DeleteVersion(version uint64) error {
 	if version == tree.latest {
 		return errors.New("cannot delete latest saved version")
 	}
-	if _, ok := tree.versions[version]; ok {
-		tree.ndb.DeleteVersion(version)
-		tree.ndb.Commit()
-
-		delete(tree.versions, version)
-
-		return nil
+	if _, ok := tree.versions[version]; !ok {
+		return ErrVersionDoesNotExist
 	}
-	return ErrVersionDoesNotExist
+
+	tree.ndb.DeleteVersion(version)
+	tree.ndb.Commit()
+
+	delete(tree.versions, version)
+
+	return nil
 }
 
 // GetVersionedWithProof gets the value under the key at the specified version


### PR DESCRIPTION
The historical queries feature is separated in two new datatypes: `VersionedTree` and `orphaningTree`.
The former keeps track of multiple of the later, and is the API for working with historical queries. The later is not exposed, and is a wrapper around `IAVLTree` which has the additional feature of keeping track of orphaned nodes.

This implementation of historical queries allows for gaps in history: it's possible to delete intermediary versions. At all times, we attempt to keep the minimal set of orphans required, since version `N` might still be depending on nodes from multiple versions `N - M`.

There is currently no automatic pruning of the tree, since the pruning strategy is to be determined by the user of the tree, ex: keep every 10 trees on disk (10, 20, 30...), or every 100 trees (100, 200, 300), or only keep the last 20 (1, 2, 3, 4...20).

The main new operations are: `SaveVersion(uint64)` and `DeleteVersion(uint64)`. There are some deliberate constraints mostly for simplicity reasons:

* You can't delete the last saved version.
* You can't save the same version twice.
* Version numbers must be > 0.
* You can't save with an empty tree (nil root).

When a new version is saved, the previous one is copied, and acts as the "working tree". When `SaveVersion` is called, it is that working tree that is saved, and the new nodes are marked with the given version.

I've added a test flag: `-test.leveldb` to run certain tests with leveldb, since there is leveldb-specific code for prefix iteration.

I've also added a `-test.fuzz-iterations` flag which takes a number of iterations to run for the fuzz test. A good number would be `-test.fuzz-iterations 2000000` which completes in 15s on my computer.

I haven't benchmarked the code yet, but the original set of operations should perform similarly. Save and Delete might be slower currently, as very little optimization has been done.

An example database which had 3 versions (`1 2 3`), where the 2nd was deleted looks like this:

```
roots/1: a7923cdb7d6b680ad4b9278959dc98d8389fe2c2
roots/3: b388298b512229ed1c1285f18a3ecfdad62dda4c

orphans/1/1/1d950b27a03b2cdff72a588ad38819755f28a3d8: 1d950b27a03b2cdff72a588ad38819755f28a3d8
orphans/1/1/a7923cdb7d6b680ad4b9278959dc98d8389fe2c2: a7923cdb7d6b680ad4b9278959dc98d8389fe2c2
orphans/1/1/8c255924ea9620ccab7247d46752bb52bf0d8ab3: 8c255924ea9620ccab7247d46752bb52bf0d8ab3
orphans/1/1/cc9d4d0a99d84dd89364811d9bfb7681a04209c0: cc9d4d0a99d84dd89364811d9bfb7681a04209c0
orphans/1/1/202d2c0f930fc88496282dd1d69cfb0473e01fd8: 202d2c0f930fc88496282dd1d69cfb0473e01fd8

nodes/1d950b27a03b2cdff72a588ad38819755f28a3d8: key0 = val0             h=0 version=1
nodes/2f348898cd0411816c89aa7c81d0e74196dc14c5: key0 = val2             h=0 version=3
nodes/8c255924ea9620ccab7247d46752bb52bf0d8ab3: key1 = val0             h=0 version=1
nodes/a7923cdb7d6b680ad4b9278959dc98d8389fe2c2: key1                    h=2 version=1
nodes/cc9d4d0a99d84dd89364811d9bfb7681a04209c0: key2                    h=1 version=1
nodes/202d2c0f930fc88496282dd1d69cfb0473e01fd8: key2 = val0             h=0 version=1
nodes/b388298b512229ed1c1285f18a3ecfdad62dda4c: key2                    h=2 version=3
nodes/339726bcc7814d2e983b7e799b2983bffa56e240: key2 = val2             h=0 version=3
nodes/2ffa1c0916cd58cbfc3a05b0a0c5f4b1150cb105: key3 = val1             h=0 version=2
nodes/c4fb4590d73dc65505d4859f3ff6bf43ff61d109: key3                    h=1 version=3
```

I implemented a fuzz tester to catch more bugs. This enabled me to fix a few edge cases I hadn't foreseen regarding orphan functionality. The output shows you the steps required to reproduce the panic:

```
iavl_tree_fuzz_test.go:121: Error after 107227 iterations (size 13):
Program panicked with: Panicked on a Sanity Check: Value missing for key e214af93bcf3e3dbda8569421e55b2436a6fdbeb

                   SET      L        c
                   SET      J        s
                   SAVE                       1
                   REMOVE   8
                   SET      i        D
                   SAVE                       2
                   SET      U        J
                   SAVE                       3
                   DELETE                     1
                >> SET      L        f
                   DELETE                     1
                   SAVE                       4
                   SET      2        D
```