### PR TITLE
linting: add gometalinter to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GOTOOLS := github.com/mitchellh/gox \
-           github.com/Masterminds/glide
+           github.com/Masterminds/glide \
+	   github.com/alecthomas/gometalinter
 
 PDFFLAGS := -pdf --nodefraction=0.1
 
@@ -52,5 +53,39 @@ exploremem:
 
 delve:
 	dlv test ./benchmarks -- -test.bench=.
+
+metalinter: tools
+	@gometalinter --install
+	gometalinter --vendor --deadline=600s --enable-all --disable=lll ./...
+
+metalinter_test: tools
+	@gometalinter --install
+	gometalinter --vendor --deadline=600s --disable-all  \
+		--enable=deadcode \
+		--enable=errcheck \
+		--enable=gas \
+		--enable=goconst \
+		--enable=goimports \
+		--enable=gosimple \
+		--enable=ineffassign \
+		--enable=misspell \
+		--enable=staticcheck \
+		--enable=safesql \
+		--enable=unconvert \
+		--enable=unused \
+		--enable=vetshadow \
+		./...
+
+		#--enable=aligncheck \
+		#--enable=dupl \
+		#--enable=gocyclo \
+		#--enable=golint \ <== comments on anything exported
+		#--enable=gotype \
+		#--enable=interfacer \
+		#--enable=megacheck \
+		#--enable=structcheck \
+		#--enable=unparam \
+		#--enable=varcheck \
+		#--enable=vet \
 
 .PHONY: all test tools

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -512,7 +512,7 @@ func testProof(t *testing.T, proof *KeyExistsProof, keyBytes, valueBytes, rootHa
 		}
 	}
 
-	// targetted changes fails...
+	// targeted changes fails...
 	proof.RootHash = MutateByteSlice(proof.RootHash)
 	assert.Error(t, proof.Verify(keyBytes, valueBytes, rootHashBytes))
 }

--- a/iavl_tree_dump.go
+++ b/iavl_tree_dump.go
@@ -50,7 +50,7 @@ type state struct {
 	Height uint64
 }
 
-// Try to interpet as merkleeyes state
+// Try to interpret as merkleeyes state
 func stateMapping(value []byte) string {
 	var s state
 	err := wire.ReadBinaryBytes(value, &s)


### PR DESCRIPTION
- introduces `make metalinter` and `make metalinter_test`. The latter should be phased out eventually when the code complies with `--enable-all`
- only fixed the typos because I'm not sure what the status is on the code. (e.g., deadcode - will it be used?)