### PR TITLE
Provide stable serialization for IAVL tree

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -86,8 +86,12 @@ func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
 	}
 
 	// otherwise, decend one more level
-	node.getLeftNode(t).traverseDepth(t, depth-1, cb)
-	node.getRightNode(t).traverseDepth(t, depth-1, cb)
+	if node.leftHash != nil {
+		node.getLeftNode(t).traverseDepth(t, depth-1, cb)
+	}
+	if node.rightHash != nil {
+		node.getRightNode(t).traverseDepth(t, depth-1, cb)
+	}
 }
 
 // position to key can calculate the appropriate sort order

--- a/chunk.go
+++ b/chunk.go
@@ -84,14 +84,13 @@ func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
 		cb(node)
 		return
 	}
+	if node.isLeaf() {
+		return
+	}
 
-	// otherwise, decend one more level
-	if node.leftHash != nil {
-		node.getLeftNode(t).traverseDepth(t, depth-1, cb)
-	}
-	if node.rightHash != nil {
-		node.getRightNode(t).traverseDepth(t, depth-1, cb)
-	}
+	// otherwise, descend one more level
+	node.getLeftNode(t).traverseDepth(t, depth-1, cb)
+	node.getRightNode(t).traverseDepth(t, depth-1, cb)
 }
 
 // position to key can calculate the appropriate sort order

--- a/chunk.go
+++ b/chunk.go
@@ -1,7 +1,6 @@
 package iavl
 
 import (
-	"math"
 	"sort"
 )
 
@@ -31,10 +30,8 @@ func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
 // GetChunkHashes returns all the "checksum" hashes for
 // the chunks that will be sent
 func GetChunkHashes(tree *Tree, depth uint) ([][]byte, uint) {
-	// Since the tree is not always perfectly balanced, we give ourselves a
-	// margin such that we don't return leaves by mistake, nor do we return
-	// a depth that isn't balanced.
-	maxDepth := uint(math.Log2(float64(tree.Size()))) - 3
+	// Account for unbalanced trees by capping the depth.
+	maxDepth := uint(tree.root.height / 2)
 	if depth > maxDepth {
 		depth = maxDepth
 	}

--- a/chunk.go
+++ b/chunk.go
@@ -173,7 +173,7 @@ func MergeChunks(left, right Chunk) Chunk {
 // iavl tree to calculate the root hash of inserting
 // all the nodes
 func (c Chunk) CalculateRoot() []byte {
-	test := NewTree(2*len(c), nil)
+	test := NewTree(nil, 2*len(c))
 	c.PopulateTree(test)
 	return test.Hash()
 }

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,111 @@
+package iavl
+
+import "sort"
+
+// Chunk is a list of ordered nodes
+// It can be sorted, merged, exported from a tree and
+// used to generate a new tree
+type Chunk []OrderedNodeData
+
+// OrderedNodeData is the data to recreate a leaf node,
+// along with a SortOrder to define a BFS insertion order
+type OrderedNodeData struct {
+	SortOrder uint64
+	NodeData
+}
+
+// NewOrderedNode creates the data from a leaf node
+func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
+	return OrderedNodeData{
+		SortOrder: prefix,
+		NodeData: NodeData{
+			Key:   leaf.key,
+			Value: leaf.value,
+		},
+	}
+}
+
+// GetChunkHashes returns all the
+func GetChunkHashes(tree *Tree, depth int) [][]byte {
+	// TODO: handle case besides depth=0
+	return [][]byte{tree.Hash()}
+}
+
+// GetChunk finds the count-th subtree at depth and
+// generates a Chunk for that data
+func GetChunk(tree *Tree, depth, count int) Chunk {
+	// TODO: handle case besides depth=0, chunk=0
+	node := tree.root
+	return getChunk(node, 0, 0)
+}
+
+// getChunk takes a node and serializes all nodes below it
+//
+// As it is part of a larger tree, prefix defines the path
+// up to this point, and depth the current depth
+// (which defines where we add to the prefix)
+//
+// TODO: make this more efficient, *Chunk as arg???
+func getChunk(node *Node, prefix uint64, depth uint) Chunk {
+	if node.isLeaf() {
+		return Chunk{NewOrderedNode(node, prefix)}
+	}
+	res := make(Chunk, 0, node.size)
+	if node.leftNode != nil {
+		left := getChunk(node.leftNode, prefix, depth+1)
+		res = append(res, left...)
+	}
+	if node.rightNode != nil {
+		offset := prefix + 1<<depth
+		right := getChunk(node.rightNode, offset, depth+1)
+		res = append(res, right...)
+	}
+	return res
+}
+
+// Sort does an inline quicksort
+func (c Chunk) Sort() {
+	sort.Slice(c, func(i, j int) bool {
+		return c[i].SortOrder < c[j].SortOrder
+	})
+}
+
+// Merge does a merge sort of the two slices,
+// assuming they were already in sorted order
+func Merge(left, right Chunk) Chunk {
+	size, i, j := len(left)+len(right), 0, 0
+	slice := make([]OrderedNodeData, size)
+
+	for k := 0; k < size; k++ {
+		if i > len(left)-1 && j <= len(right)-1 {
+			slice[k] = right[j]
+			j++
+		} else if j > len(right)-1 && i <= len(left)-1 {
+			slice[k] = left[i]
+			i++
+		} else if left[i].SortOrder < right[j].SortOrder {
+			slice[k] = left[i]
+			i++
+		} else {
+			slice[k] = right[j]
+			j++
+		}
+	}
+	return Chunk(slice)
+}
+
+// CalculateRoot creates a temporary in-memory
+// iavl tree to calculate the root hash of inserting
+// all the nodes
+func (c Chunk) CalculateRoot() []byte {
+	test := NewTree(2*len(c), nil)
+	c.PopulateTree(test)
+	return test.Hash()
+}
+
+// PopulateTree adds all the chunks in order to the given tree
+func (c Chunk) PopulateTree(empty *Tree) {
+	for _, data := range c {
+		empty.Set(data.Key, data.Value)
+	}
+}

--- a/chunk.go
+++ b/chunk.go
@@ -1,6 +1,9 @@
 package iavl
 
-import "sort"
+import (
+	"math"
+	"sort"
+)
 
 // Chunk is a list of ordered nodes
 // It can be sorted, merged, exported from a tree and
@@ -27,13 +30,21 @@ func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
 
 // GetChunkHashes returns all the "checksum" hashes for
 // the chunks that will be sent
-func GetChunkHashes(tree *Tree, depth uint) [][]byte {
+func GetChunkHashes(tree *Tree, depth uint) ([][]byte, uint) {
+	// Since the tree is not always perfectly balanced, we give ourselves a
+	// margin such that we don't return leaves by mistake, nor do we return
+	// a depth that isn't balanced.
+	maxDepth := uint(math.Log2(float64(tree.Size()))) - 3
+	if depth > maxDepth {
+		depth = maxDepth
+	}
+
 	nodes := getNodes(tree, depth)
 	res := make([][]byte, len(nodes))
 	for i, n := range nodes {
 		res[i] = n.hash
 	}
-	return res
+	return res, depth
 }
 
 // getNodes returns an array of nodes at the given depth

--- a/chunk.go
+++ b/chunk.go
@@ -90,7 +90,7 @@ func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
 	node.getRightNode(t).traverseDepth(t, depth-1, cb)
 }
 
-// position to key can calculte the appropriate sort order
+// position to key can calculate the appropriate sort order
 // for the count-th node at a given depth, assuming a full
 // tree above this height.
 func positionToKey(depth, count uint) (key uint64) {

--- a/chunk.go
+++ b/chunk.go
@@ -38,13 +38,24 @@ func GetChunkHashes(tree *Tree, depth uint) [][]byte {
 
 // getNodes returns an array of nodes at the given depth
 func getNodes(tree *Tree, depth uint) []*Node {
+	nodes := make([]*Node, 0, 1<<depth)
+	tree.root.traverseDepth(depth, func(node *Node) {
+		nodes = append(nodes, node)
+	})
+	return nodes
+}
+
+// call cb for every node exactly depth levels below it
+// depth first search to return in tree ordering
+func (node *Node) traverseDepth(depth uint, cb func(*Node)) {
+	// base case
 	if depth == 0 {
-		return []*Node{tree.root}
-	} else if depth == 1 {
-		return []*Node{tree.root.leftNode, tree.root.rightNode}
-	} else {
-		panic("TODO")
+		cb(node)
+		return
 	}
+	// otherwise, decend one more level
+	node.leftNode.traverseDepth(depth-1, cb)
+	node.rightNode.traverseDepth(depth-1, cb)
 }
 
 // position to key can calculte the appropriate sort order

--- a/chunk.go
+++ b/chunk.go
@@ -7,19 +7,19 @@ import (
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
-// Chunk is a list of ordered nodes
+// Chunk is a list of ordered nodes.
 // It can be sorted, merged, exported from a tree and
-// used to generate a new tree
+// used to generate a new tree.
 type Chunk []OrderedNodeData
 
 // OrderedNodeData is the data to recreate a leaf node,
-// along with a SortOrder to define a BFS insertion order
+// along with a SortOrder to define a BFS insertion order.
 type OrderedNodeData struct {
 	SortOrder uint64
 	NodeData
 }
 
-// NewOrderedNode creates the data from a leaf node
+// NewOrderedNode creates the data from a leaf node.
 func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
 	return OrderedNodeData{
 		SortOrder: prefix,
@@ -31,7 +31,7 @@ func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
 }
 
 // getChunkHashes returns all the "checksum" hashes for
-// the chunks that will be sent
+// the chunks that will be sent.
 func getChunkHashes(tree *Tree, depth uint) ([][]byte, [][]byte, uint, error) {
 	maxDepth := uint(tree.root.height / 2)
 	if depth > maxDepth {
@@ -67,7 +67,7 @@ func GetChunkHashesWithProofs(tree *Tree) ([][]byte, []*InnerKeyProof, uint) {
 	return hashes, proofs, depth
 }
 
-// getNodes returns an array of nodes at the given depth
+// getNodes returns an array of nodes at the given depth.
 func getNodes(tree *Tree, depth uint) []*Node {
 	nodes := make([]*Node, 0, 1<<depth)
 	tree.root.traverseDepth(tree, depth, func(node *Node) {
@@ -77,7 +77,7 @@ func getNodes(tree *Tree, depth uint) []*Node {
 }
 
 // call cb for every node exactly depth levels below it
-// depth first search to return in tree ordering
+// depth first search to return in tree ordering.
 func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
 	// base case
 	if depth == 0 {
@@ -106,7 +106,7 @@ func positionToKey(depth, count uint) (key uint64) {
 }
 
 // GetChunk finds the count-th subtree at depth and
-// generates a Chunk for that data
+// generates a Chunk for that data.
 func GetChunk(tree *Tree, depth, count uint) Chunk {
 	node := getNodes(tree, depth)[count]
 	prefix := positionToKey(depth, count)
@@ -137,7 +137,7 @@ func getChunk(t *Tree, node *Node, prefix uint64, depth uint) Chunk {
 	return res
 }
 
-// Sort does an inline quicksort
+// Sort does an inline quicksort.
 func (c Chunk) Sort() {
 	sort.Slice(c, func(i, j int) bool {
 		return c[i].SortOrder < c[j].SortOrder
@@ -145,7 +145,7 @@ func (c Chunk) Sort() {
 }
 
 // MergeChunks does a merge sort of the two Chunks,
-// assuming they were already in sorted order
+// assuming they were already in sorted order.
 func MergeChunks(left, right Chunk) Chunk {
 	size, i, j := len(left)+len(right), 0, 0
 	slice := make([]OrderedNodeData, size)
@@ -170,14 +170,14 @@ func MergeChunks(left, right Chunk) Chunk {
 
 // CalculateRoot creates a temporary in-memory
 // iavl tree to calculate the root hash of inserting
-// all the nodes
+// all the nodes.
 func (c Chunk) CalculateRoot() []byte {
 	test := NewTree(nil, 2*len(c))
 	c.PopulateTree(test)
 	return test.Hash()
 }
 
-// PopulateTree adds all the chunks in order to the given tree
+// PopulateTree adds all the chunks in order to the given tree.
 func (c Chunk) PopulateTree(empty *Tree) {
 	for _, data := range c {
 		empty.Set(data.Key, data.Value)

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,28 @@
+package iavl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleChunk(t *testing.T) {
+	require := require.New(t)
+
+	// get the chunk info we use
+	tree := makeRandomTree(TreeSize)
+	hashes := GetChunkHashes(tree, 0)
+	require.Equal(1, len(hashes))
+	hash := hashes[0]
+	require.Equal(tree.Hash(), hash)
+
+	// get tree as one chunk
+	chunk := GetChunk(tree, 0, 0)
+	require.NotEmpty(chunk)
+	require.Equal(tree.Size(), len(chunk))
+
+	// sort chunk and check integrity
+	chunk.Sort()
+	check := chunk.CalculateRoot()
+	require.Equal(hash, check)
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -91,7 +91,7 @@ func TestChunkProofs(t *testing.T) {
 }
 
 func makeAlphabetTree() *Tree {
-	t := NewTree(26, db.NewMemDB())
+	t := NewTree(db.NewMemDB(), 26)
 	alpha := []byte("abcdefghijklmnopqrstuvwxyz")
 
 	for _, a := range alpha {

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -35,8 +35,8 @@ func TestMultipleChunks(t *testing.T) {
 	}{
 		{0},
 		{1},
-		// {4},
-		// {7},
+		{4},
+		{7},
 	}
 
 	// get the chunk info we use

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -11,7 +11,7 @@ func TestSimpleChunk(t *testing.T) {
 
 	// get the chunk info we use
 	tree := makeRandomTree(TreeSize)
-	hashes := GetChunkHashes(tree, 0)
+	hashes, _ := GetChunkHashes(tree, 0)
 	require.Equal(1, len(hashes))
 	hash := hashes[0]
 	require.Equal(tree.Hash(), hash)
@@ -37,26 +37,27 @@ func TestMultipleChunks(t *testing.T) {
 		{1},
 		{4},
 		{7},
+		{16},
 	}
 
 	// get the chunk info we use
 	tree := makeRandomTree(TreeSize)
 
 	for _, tc := range cases {
-		hashes := GetChunkHashes(tree, tc.depth)
+		hashes, depth := GetChunkHashes(tree, tc.depth)
 		numChunks := len(hashes)
-		require.Equal(1<<tc.depth, numChunks, "%d", tc.depth)
+		require.Equal(1<<depth, numChunks, "%d", tc.depth)
 
 		var accum Chunk
 		for i := 0; i < numChunks; i++ {
 			// get tree as one chunk
-			chunk := GetChunk(tree, tc.depth, uint(i))
-			require.NotEmpty(chunk, "%d/%d", tc.depth, i)
+			chunk := GetChunk(tree, depth, uint(i))
+			require.NotEmpty(chunk, "%d/%d", depth, i)
 
 			// sort chunk and check integrity
 			chunk.Sort()
 			check := chunk.CalculateRoot()
-			require.Equal(hashes[i], check, "%d/%d", tc.depth, i)
+			require.Equal(hashes[i], check, "%d/%d", depth, i)
 
 			// add this chunk to our accum
 			accum = MergeChunks(accum, chunk)

--- a/path.go
+++ b/path.go
@@ -23,8 +23,8 @@ func (p *PathToKey) String() string {
 
 // verify check that the leafNode's hash matches the path's LeafHash and that
 // the root is the merkle hash of all the inner nodes.
-func (p *PathToKey) verify(leafNode proofLeafNode, root []byte) error {
-	hash := leafNode.Hash()
+func (p *PathToKey) verify(leafHash []byte, root []byte) error {
+	hash := leafHash
 	for _, branch := range p.InnerNodes {
 		hash = branch.Hash(hash)
 	}
@@ -92,7 +92,7 @@ type pathWithNode struct {
 }
 
 func (p *pathWithNode) verify(root []byte) error {
-	return p.Path.verify(p.Node, root)
+	return p.Path.verify(p.Node.Hash(), root)
 }
 
 // verifyPaths verifies the left and right paths individually, and makes sure

--- a/proof_key.go
+++ b/proof_key.go
@@ -48,7 +48,7 @@ func (proof *KeyExistsProof) Verify(key []byte, value []byte, root []byte) error
 	if key == nil || value == nil {
 		return errors.WithStack(ErrInvalidInputs)
 	}
-	return proof.PathToKey.verify(proofLeafNode{key, value, proof.Version}, root)
+	return proof.PathToKey.verify(proofLeafNode{key, value, proof.Version}.Hash(), root)
 }
 
 // Bytes returns a go-wire binary serialization

--- a/proof_range.go
+++ b/proof_range.go
@@ -182,7 +182,7 @@ func (proof *KeyRangeProof) Verify(
 			ValueBytes: values[i],
 			Version:    proof.Version,
 		}
-		if err := path.verify(leafNode, root); err != nil {
+		if err := path.verify(leafNode.Hash(), root); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/serialize.go
+++ b/serialize.go
@@ -1,0 +1,33 @@
+package iavl
+
+// KeyValue groups together a key and a value for return codes
+type KeyValue struct {
+	Key   []byte
+	Value []byte
+}
+
+// SerializeFunc is any implementation that can serialize
+// an iavl Tree
+type SerializeFunc func(*Tree) []KeyValue
+
+// Restore will take an (empty) tree restore it
+// from the keys returned from a SerializeFunc
+func Restore(empty *Tree, kvs []KeyValue) {
+	for _, kv := range kvs {
+		empty.Set(kv.Key, kv.Value)
+	}
+	empty.Hash()
+}
+
+// InOrderSerializer returns all key-values in the
+// key order (as stored). May be nice to read, but
+// when recovering, it will create a different.
+func InOrderSerializer(tree *Tree) []KeyValue {
+	res := make([]KeyValue, 0, tree.Size())
+	tree.Iterate(func(key, value []byte) bool {
+		kv := KeyValue{Key: key, Value: value}
+		res = append(res, kv)
+		return false
+	})
+	return res
+}

--- a/serialize.go
+++ b/serialize.go
@@ -71,7 +71,7 @@ func StableSerializeBFS(t *Tree, root *Node) []NodeData {
 	return nds
 }
 
-// StableSerialize exports the key value pairs of the tree
+// StableSerializeFrey exports the key value pairs of the tree
 // in an order, such that when Restored from those keys, the
 // new tree would have the same structure (and thus same
 // shape) as the original tree.
@@ -87,7 +87,7 @@ func StableSerializeBFS(t *Tree, root *Node) []NodeData {
 // 1, 5
 // 1, 5, 3, 7
 // 1, 5, 3, 7, 2, 4, 6, 8
-func StableSerialize(t *Tree, top *Node) []NodeData {
+func StableSerializeFrey(t *Tree, top *Node) []NodeData {
 	if top == nil {
 		return nil
 	}

--- a/serialize.go
+++ b/serialize.go
@@ -1,18 +1,18 @@
 package iavl
 
-// KeyValue groups together a key and a value for return codes
-type KeyValue struct {
+// NodeData groups together a key and a value for return codes
+type NodeData struct {
 	Key   []byte
 	Value []byte
 }
 
 // SerializeFunc is any implementation that can serialize
 // an iavl Tree
-type SerializeFunc func(*Tree) []KeyValue
+type SerializeFunc func(*Tree) []NodeData
 
 // Restore will take an (empty) tree restore it
 // from the keys returned from a SerializeFunc
-func Restore(empty *Tree, kvs []KeyValue) {
+func Restore(empty *Tree, kvs []NodeData) {
 	for _, kv := range kvs {
 		empty.Set(kv.Key, kv.Value)
 	}
@@ -22,10 +22,10 @@ func Restore(empty *Tree, kvs []KeyValue) {
 // InOrderSerialize returns all key-values in the
 // key order (as stored). May be nice to read, but
 // when recovering, it will create a different.
-func InOrderSerialize(tree *Tree) []KeyValue {
-	res := make([]KeyValue, 0, tree.Size())
+func InOrderSerialize(tree *Tree) []NodeData {
+	res := make([]NodeData, 0, tree.Size())
 	tree.Iterate(func(key, value []byte) bool {
-		kv := KeyValue{Key: key, Value: value}
+		kv := NodeData{Key: key, Value: value}
 		res = append(res, kv)
 		return false
 	})
@@ -41,14 +41,14 @@ func InOrderSerialize(tree *Tree) []KeyValue {
 // of the left half and the leftmost node of the righthalf.
 // Then go down a level...
 // each time adding leftmost node of the right side.
-// (depth first search)
+// (bredth first search)
 //
 // Imagine 8 nodes in a balanced tree, split in half each time
 // 1
 // 1, 5
 // 1, 5, 3, 7
 // 1, 5, 3, 7, 2, 4, 6, 8
-func StableSerialize(tree *Tree) []KeyValue {
+func StableSerialize(tree *Tree) []NodeData {
 	top := tree.root
 	if top == nil {
 		return nil
@@ -59,7 +59,7 @@ func StableSerialize(tree *Tree) []KeyValue {
 	queue = append(queue, top)
 
 	// to store all results - started with
-	res := make([]KeyValue, 0, tree.Size())
+	res := make([]NodeData, 0, tree.Size())
 	left := leftmost(top)
 	if left != nil {
 		res = append(res, *left)
@@ -85,7 +85,7 @@ func StableSerialize(tree *Tree) []KeyValue {
 				res = append(res, *left)
 			}
 		} else if isLeaf(r) {
-			kv := KeyValue{Key: r.key, Value: r.value}
+			kv := NodeData{Key: r.key, Value: r.value}
 			res = append(res, kv)
 		}
 	}
@@ -101,12 +101,12 @@ func isLeaf(n *Node) bool {
 	return n != nil && n.isLeaf()
 }
 
-func leftmost(node *Node) *KeyValue {
+func leftmost(node *Node) *NodeData {
 	for isInner(node) {
 		node = node.leftNode
 	}
 	if node == nil {
 		return nil
 	}
-	return &KeyValue{Key: node.key, Value: node.value}
+	return &NodeData{Key: node.key, Value: node.value}
 }

--- a/serialize.go
+++ b/serialize.go
@@ -19,10 +19,10 @@ func Restore(empty *Tree, kvs []KeyValue) {
 	empty.Hash()
 }
 
-// InOrderSerializer returns all key-values in the
+// InOrderSerialize returns all key-values in the
 // key order (as stored). May be nice to read, but
 // when recovering, it will create a different.
-func InOrderSerializer(tree *Tree) []KeyValue {
+func InOrderSerialize(tree *Tree) []KeyValue {
 	res := make([]KeyValue, 0, tree.Size())
 	tree.Iterate(func(key, value []byte) bool {
 		kv := KeyValue{Key: key, Value: value}
@@ -30,4 +30,83 @@ func InOrderSerializer(tree *Tree) []KeyValue {
 		return false
 	})
 	return res
+}
+
+// StableSerialize exports the key value pairs of the tree
+// in an order, such that when Restored from those keys, the
+// new tree would have the same structure (and thus same
+// shape) as the original tree.
+//
+// the algorithm is basically this: take the leftmost node
+// of the left half and the leftmost node of the righthalf.
+// Then go down a level...
+// each time adding leftmost node of the right side.
+// (depth first search)
+//
+// Imagine 8 nodes in a balanced tree, split in half each time
+// 1
+// 1, 5
+// 1, 5, 3, 7
+// 1, 5, 3, 7, 2, 4, 6, 8
+func StableSerialize(tree *Tree) []KeyValue {
+	top := tree.root
+	if top == nil {
+		return nil
+	}
+
+	// store all pending nodes for depth-first search
+	queue := make([]*Node, 0, tree.Size())
+	queue = append(queue, top)
+
+	// to store all results - started with
+	res := make([]KeyValue, 0, tree.Size())
+	left := leftmost(top)
+	if left != nil {
+		res = append(res, *left)
+	}
+
+	var n *Node
+	for len(queue) > 0 {
+		// pop
+		n, queue = queue[0], queue[1:]
+
+		// l := n.getLeftNode(tree)
+		l := n.leftNode
+		if isInner(l) {
+			queue = append(queue, l)
+		}
+
+		// r := n.getRightNode(tree)
+		r := n.rightNode
+		if isInner(r) {
+			queue = append(queue, r)
+			left = leftmost(r)
+			if left != nil {
+				res = append(res, *left)
+			}
+		} else if isLeaf(r) {
+			kv := KeyValue{Key: r.key, Value: r.value}
+			res = append(res, kv)
+		}
+	}
+
+	return res
+}
+
+func isInner(n *Node) bool {
+	return n != nil && !n.isLeaf()
+}
+
+func isLeaf(n *Node) bool {
+	return n != nil && n.isLeaf()
+}
+
+func leftmost(node *Node) *KeyValue {
+	for isInner(node) {
+		node = node.leftNode
+	}
+	if node == nil {
+		return nil
+	}
+	return &KeyValue{Key: node.key, Value: node.value}
 }

--- a/serialize.go
+++ b/serialize.go
@@ -32,6 +32,39 @@ func InOrderSerialize(tree *Tree) []NodeData {
 	return res
 }
 
+func StableSerializeBFS(tree *Tree) []NodeData {
+	if tree.root == nil {
+		return nil
+	}
+
+	size := tree.Size()
+	visited := map[string][]byte{}
+	keys := make([][]byte, 0, size)
+	numKeys := -1
+
+	// Breadth-first search. At every depth, add keys in search order. Keep
+	// going as long as we find keys at that depth. When we reach a leaf, set
+	// its value in the visited map.
+	for depth := uint(0); len(keys) > numKeys; depth++ {
+		numKeys = len(keys)
+		tree.root.traverseDepth(tree, depth, func(node *Node) {
+			if _, ok := visited[string(node.key)]; !ok {
+				keys = append(keys, node.key)
+				visited[string(node.key)] = nil
+			}
+			if node.isLeaf() {
+				visited[string(node.key)] = node.value
+			}
+		})
+	}
+
+	nds := make([]NodeData, size)
+	for i, k := range keys {
+		nds[i] = NodeData{k, visited[string(k)]}
+	}
+	return nds
+}
+
 // StableSerialize exports the key value pairs of the tree
 // in an order, such that when Restored from those keys, the
 // new tree would have the same structure (and thus same

--- a/serialize.go
+++ b/serialize.go
@@ -1,6 +1,6 @@
 package iavl
 
-// NodeData groups together a key and a value for return codes
+// NodeData groups together a key and a value for return codes.
 type NodeData struct {
 	Key   []byte
 	Value []byte
@@ -11,7 +11,7 @@ type NodeData struct {
 type SerializeFunc func(*Tree, *Node) []NodeData
 
 // Restore will take an (empty) tree restore it
-// from the keys returned from a SerializeFunc
+// from the keys returned from a SerializeFunc.
 func Restore(empty *Tree, kvs []NodeData) {
 	for _, kv := range kvs {
 		empty.Set(kv.Key, kv.Value)
@@ -34,6 +34,7 @@ func InOrderSerialize(t *Tree, root *Node) []NodeData {
 	return res
 }
 
+// StableSerializeBFS serializes the tree in a breadth-first manner.
 func StableSerializeBFS(t *Tree, root *Node) []NodeData {
 	if root == nil {
 		return nil

--- a/serialize.go
+++ b/serialize.go
@@ -47,6 +47,10 @@ func StableSerializeBFS(t *Tree, root *Node) []NodeData {
 	// Breadth-first search. At every depth, add keys in search order. Keep
 	// going as long as we find keys at that depth. When we reach a leaf, set
 	// its value in the visited map.
+	// Since we have an AVL+ tree, the inner nodes contain only keys and not
+	// values, while the leaves contain both. Note also that there are N-1 inner
+	// nodes for N keys, so one of the leaf keys is only set once we reach the leaves
+	// of the tree.
 	for depth := uint(0); len(keys) > numKeys; depth++ {
 		numKeys = len(keys)
 		root.traverseDepth(t, depth, func(node *Node) {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,0 +1,52 @@
+package iavl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TreeSize is the number of nodes in our test trees
+const TreeSize = 1000
+
+func TestSerialize(t *testing.T) {
+	require := require.New(t)
+
+	cases := []struct {
+		algo     SerializeFunc
+		sameHash bool
+	}{
+		{InOrderSerializer, false},
+	}
+
+	for i, tc := range cases {
+		tree := makeRandomTree(TreeSize)
+		stored := tc.algo(tree)
+		require.NotNil(stored, "%d", i)
+		require.Equal(len(stored), tree.Size(), "%d", i)
+		origHash := tree.Hash()
+
+		empty := NewTree(TreeSize, nil)
+		require.Equal(0, empty.Size(), "%d", i)
+		Restore(empty, stored)
+		require.Equal(len(stored), empty.Size(), "%d", i)
+
+		newHash := empty.Hash()
+		if tc.sameHash {
+			require.Equal(origHash, newHash, "%d", i)
+		} else {
+			require.NotEqual(origHash, newHash, "%d", i)
+		}
+	}
+}
+
+// TODO: add some deletes in there as well?
+func makeRandomTree(nodes int) *Tree {
+	tree := NewTree(nodes, nil)
+	for i := 0; i <= nodes; i++ {
+		k := randBytes(16)
+		v := randBytes(32)
+		tree.Set(k, v)
+	}
+	return tree
+}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -30,7 +30,7 @@ func TestSerialize(t *testing.T) {
 		origHash := tree.Hash()
 		require.NotNil(origHash)
 
-		empty := NewTree(TreeSize, nil)
+		empty := NewTree(nil, TreeSize)
 		require.Equal(0, empty.Size(), "%d", i)
 		Restore(empty, stored)
 		require.Equal(tree.Size(), empty.Size(), "%d", i)
@@ -47,7 +47,7 @@ func TestSerialize(t *testing.T) {
 
 // TODO: add some deletes in there as well?
 func makeRandomTree(nodes int) *Tree {
-	tree := NewTree(nodes, db.NewMemDB())
+	tree := NewTree(db.NewMemDB(), nodes)
 
 	for i := 0; i <= nodes; i++ {
 		k := randBytes(16)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -18,7 +18,7 @@ func TestSerialize(t *testing.T) {
 		sameHash bool
 	}{
 		{InOrderSerialize, false},
-		{StableSerialize, true},
+		{StableSerializeFrey, true},
 		{StableSerializeBFS, true},
 	}
 

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -51,5 +51,6 @@ func makeRandomTree(nodes int) *Tree {
 		v := randBytes(32)
 		tree.Set(k, v)
 	}
+	tree.Hash()
 	return tree
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TreeSize is the number of nodes in our test trees
-const TreeSize = 1000
+const TreeSize = 10000
 
 func TestSerialize(t *testing.T) {
 	require := require.New(t)
@@ -16,22 +16,25 @@ func TestSerialize(t *testing.T) {
 		algo     SerializeFunc
 		sameHash bool
 	}{
-		{InOrderSerializer, false},
+		{InOrderSerialize, false},
+		{StableSerialize, true},
 	}
 
 	for i, tc := range cases {
 		tree := makeRandomTree(TreeSize)
 		stored := tc.algo(tree)
 		require.NotNil(stored, "%d", i)
-		require.Equal(len(stored), tree.Size(), "%d", i)
+		require.Equal(tree.Size(), len(stored), "%d", i)
 		origHash := tree.Hash()
+		require.NotNil(origHash)
 
 		empty := NewTree(TreeSize, nil)
 		require.Equal(0, empty.Size(), "%d", i)
 		Restore(empty, stored)
-		require.Equal(len(stored), empty.Size(), "%d", i)
+		require.Equal(tree.Size(), empty.Size(), "%d", i)
 
 		newHash := empty.Hash()
+		require.NotNil(newHash)
 		if tc.sameHash {
 			require.Equal(origHash, newHash, "%d", i)
 		} else {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -24,7 +24,7 @@ func TestSerialize(t *testing.T) {
 
 	for i, tc := range cases {
 		tree := makeRandomTree(TreeSize)
-		stored := tc.algo(tree)
+		stored := tc.algo(tree, tree.root)
 		require.NotNil(stored, "%d", i)
 		require.Equal(tree.Size(), len(stored), "%d", i)
 		origHash := tree.Hash()

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -19,6 +19,7 @@ func TestSerialize(t *testing.T) {
 	}{
 		{InOrderSerialize, false},
 		{StableSerialize, true},
+		{StableSerializeBFS, true},
 	}
 
 	for i, tc := range cases {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tmlibs/db"
 )
 
 // TreeSize is the number of nodes in our test trees
@@ -45,7 +46,8 @@ func TestSerialize(t *testing.T) {
 
 // TODO: add some deletes in there as well?
 func makeRandomTree(nodes int) *Tree {
-	tree := NewTree(nodes, nil)
+	tree := NewTree(nodes, db.NewMemDB())
+
 	for i := 0; i <= nodes; i++ {
 		k := randBytes(16)
 		v := randBytes(32)


### PR DESCRIPTION
Since the structure of the tree (and thus the hash) is dependent on the insertion order of the keys,
we cannot simply dump all key/value pairs and restore them, if we wish to copy a tree from one node to the other (and maintain the root hash).

However, if we could determine an ordering of the key/value pairs, which would produce the current structure when loaded into an empty tree, we could then have a portable and efficient serialization format.

I came up with an interesting idea of constantly bisecting the tree and adding the leftmost leaf for each new section for which we have no node. Wrote test code and it seems to work. Please review it:
`serialize.go:StableSerialize`

Note, that this needs some more issues for production:
  * For versioned tree the height is part of the hash... that must be persisted and restored as well
  * Works with in-memory tree, need to `s/n.leftNode/n.getLeftNode()/` to load data from the disk as needed.
  * We should have some streaming/chunked format for this rather than storing everything in memory