### PR TITLE
Auto-increment version on save

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -208,7 +208,7 @@ func TestRemove(t *testing.T) {
 			key := keys[mrand.Int31n(l)]
 			t1.Remove(key)
 		}
-		t1.SaveVersion(int64(i))
+		t1.SaveVersion()
 	}
 }
 
@@ -373,7 +373,7 @@ func TestPersistence(t *testing.T) {
 	for key, value := range records {
 		t1.Set([]byte(key), []byte(value))
 	}
-	t1.SaveVersion(1)
+	t1.SaveVersion()
 
 	// Load a tree
 	t2 := NewVersionedTree(0, db)
@@ -398,7 +398,7 @@ func TestProof(t *testing.T) {
 	}
 
 	// Persist the items so far
-	tree.SaveVersion(1)
+	tree.SaveVersion()
 
 	// Add more items so it's not all persisted
 	for i := 0; i < 100; i++ {

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -28,7 +28,7 @@ func prepareTree(db db.DB, size, keyLen, dataLen int) (*iavl.VersionedTree, [][]
 		keys[i] = key
 	}
 	t.Hash()
-	t.SaveVersion(t.LatestVersion() + 1)
+	t.SaveVersion()
 	runtime.GC()
 	return t, keys
 }
@@ -53,7 +53,7 @@ func runInsert(b *testing.B, t *iavl.VersionedTree, keyLen, dataLen, blockSize i
 		t.Set(randBytes(keyLen), randBytes(dataLen))
 		if i%blockSize == 0 {
 			t.Hash()
-			t.SaveVersion(t.LatestVersion() + 1)
+			t.SaveVersion()
 		}
 	}
 	return t
@@ -66,7 +66,7 @@ func runUpdate(b *testing.B, t *iavl.VersionedTree, dataLen, blockSize int, keys
 		t.Set(key, randBytes(dataLen))
 		if i%blockSize == 0 {
 			t.Hash()
-			t.SaveVersion(t.LatestVersion() + 1)
+			t.SaveVersion()
 		}
 	}
 	return t
@@ -82,7 +82,7 @@ func runDelete(b *testing.B, t *iavl.VersionedTree, blockSize int, keys [][]byte
 		t.Remove(key)
 		if i%blockSize == 0 {
 			t.Hash()
-			t.SaveVersion(t.LatestVersion() + 1)
+			t.SaveVersion()
 		}
 	}
 	return t
@@ -118,7 +118,7 @@ func runBlock(b *testing.B, t *iavl.VersionedTree, keyLen, dataLen, blockSize in
 
 		// at the end of a block, move it all along....
 		real.Hash()
-		real.SaveVersion(real.LatestVersion() + 1)
+		real.SaveVersion()
 		lastCommit = real
 	}
 

--- a/orphaning_tree.go
+++ b/orphaning_tree.go
@@ -43,8 +43,11 @@ func (tree *orphaningTree) unorphan(hash []byte) {
 	tree.ndb.Unorphan(hash)
 }
 
-// Save the underlying Tree. Saves orphans too.
-func (tree *orphaningTree) Save() {
+// SaveAs saves the underlying Tree and assigns it a new version.
+// Saves orphans too.
+func (tree *orphaningTree) SaveAs(version int64) {
+	tree.version = version
+
 	// Save the current tree. For each saved node, we delete any existing
 	// orphan entries in the previous trees.  This is necessary because
 	// sometimes tree re-balancing causes nodes to be incorrectly marked as
@@ -53,7 +56,7 @@ func (tree *orphaningTree) Save() {
 	tree.ndb.SaveBranch(tree.root, func(node *Node) {
 		tree.unorphan(node._hash())
 	})
-	tree.ndb.SaveOrphans(tree.version+1, tree.orphans)
+	tree.ndb.SaveOrphans(tree.version, tree.orphans)
 }
 
 // Add orphans to the orphan list. Doesn't write to disk.

--- a/proof.go
+++ b/proof.go
@@ -202,7 +202,6 @@ func (t *Tree) keyAbsentProof(key []byte) (*KeyAbsentProof, error) {
 
 	proof := &KeyAbsentProof{
 		RootHash: t.root.hash,
-		Version:  t.root.version,
 	}
 	if err := t.constructKeyAbsentProof(key, proof); err != nil {
 		return nil, errors.Wrap(err, "could not construct proof of non-existence")

--- a/proof_key.go
+++ b/proof_key.go
@@ -22,6 +22,12 @@ type KeyProof interface {
 	Bytes() []byte
 }
 
+const (
+	// Used for serialization of proofs.
+	keyExistsMagicNumber = 0x50
+	keyAbsentMagicNumber = 0x51
+)
+
 // KeyExistsProof represents a proof of existence of a single key.
 type KeyExistsProof struct {
 	RootHash data.Bytes `json:"root_hash"`
@@ -47,11 +53,11 @@ func (proof *KeyExistsProof) Verify(key []byte, value []byte, root []byte) error
 
 // Bytes returns a go-wire binary serialization
 func (proof *KeyExistsProof) Bytes() []byte {
-	return wire.BinaryBytes(proof)
+	return append([]byte{keyExistsMagicNumber}, wire.BinaryBytes(proof)...)
 }
 
-// ReadKeyExistsProof will deserialize a KeyExistsProof from bytes.
-func ReadKeyExistsProof(data []byte) (*KeyExistsProof, error) {
+// readKeyExistsProof will deserialize a KeyExistsProof from bytes.
+func readKeyExistsProof(data []byte) (*KeyExistsProof, error) {
 	proof := new(KeyExistsProof)
 	err := wire.ReadBinaryBytes(data, &proof)
 	return proof, err
@@ -94,12 +100,32 @@ func (proof *KeyAbsentProof) Verify(key, value []byte, root []byte) error {
 
 // Bytes returns a go-wire binary serialization
 func (proof *KeyAbsentProof) Bytes() []byte {
-	return wire.BinaryBytes(proof)
+	return append([]byte{keyAbsentMagicNumber}, wire.BinaryBytes(proof)...)
 }
 
-// ReadKeyAbsentProof will deserialize a KeyAbsentProof from bytes.
-func ReadKeyAbsentProof(data []byte) (*KeyAbsentProof, error) {
+// readKeyAbsentProof will deserialize a KeyAbsentProof from bytes.
+func readKeyAbsentProof(data []byte) (*KeyAbsentProof, error) {
 	proof := new(KeyAbsentProof)
 	err := wire.ReadBinaryBytes(data, &proof)
 	return proof, err
+}
+
+func ReadKeyProof(data []byte) (KeyProof, error) {
+	var err error
+	var n int
+
+	buf := bytes.NewBuffer(data)
+
+	b := wire.ReadByte(buf, &n, &err)
+	if err != nil {
+		return nil, err
+	}
+
+	switch b {
+	case keyExistsMagicNumber:
+		return readKeyExistsProof(buf.Bytes())
+	case keyAbsentMagicNumber:
+		return readKeyAbsentProof(buf.Bytes())
+	}
+	return nil, errors.New("unrecognized proof")
 }

--- a/proof_key.go
+++ b/proof_key.go
@@ -60,7 +60,6 @@ func ReadKeyExistsProof(data []byte) (*KeyExistsProof, error) {
 // KeyAbsentProof represents a proof of the absence of a single key.
 type KeyAbsentProof struct {
 	RootHash data.Bytes `json:"root_hash"`
-	Version  int64      `json:"version"`
 
 	Left  *pathWithNode `json:"left"`
 	Right *pathWithNode `json:"right"`

--- a/proof_key.go
+++ b/proof_key.go
@@ -110,22 +110,18 @@ func readKeyAbsentProof(data []byte) (*KeyAbsentProof, error) {
 	return proof, err
 }
 
+// ReadKeyProof reads a KeyProof from a byte-slice.
 func ReadKeyProof(data []byte) (KeyProof, error) {
-	var err error
-	var n int
-
-	buf := bytes.NewBuffer(data)
-
-	b := wire.ReadByte(buf, &n, &err)
-	if err != nil {
-		return nil, err
+	if len(data) == 0 {
+		return nil, errors.New("proof bytes are empty")
 	}
+	b, val := data[0], data[1:]
 
 	switch b {
 	case keyExistsMagicNumber:
-		return readKeyExistsProof(buf.Bytes())
+		return readKeyExistsProof(val)
 	case keyAbsentMagicNumber:
-		return readKeyAbsentProof(buf.Bytes())
+		return readKeyAbsentProof(val)
 	}
 	return nil, errors.New("unrecognized proof")
 }

--- a/proof_key_test.go
+++ b/proof_key_test.go
@@ -29,9 +29,8 @@ func TestSerializeProofs(t *testing.T) {
 	require.Nil(err, "%+v", err)
 	require.NoError(proof2.Verify(key, val, root))
 
-	if _, ok := proof2.(*KeyExistsProof); !ok {
-		require.FailNow("Proof should be *KeyExistsProof")
-	}
+	_, ok := proof2.(*KeyExistsProof)
+	require.True(ok, "Proof should be *KeyExistsProof")
 
 	// test with key absent
 	key = []byte{0x38}

--- a/proof_key_test.go
+++ b/proof_key_test.go
@@ -23,12 +23,15 @@ func TestSerializeProofs(t *testing.T) {
 	val, proof, err := tree.GetWithProof(key)
 	require.Nil(err, "%+v", err)
 	require.NotNil(val)
+
 	bin := proof.Bytes()
-	eproof, err := ReadKeyExistsProof(bin)
+	proof2, err := ReadKeyProof(bin)
 	require.Nil(err, "%+v", err)
-	require.NoError(eproof.Verify(key, val, root))
-	_, err = ReadKeyAbsentProof(bin)
-	require.NotNil(err)
+	require.NoError(proof2.Verify(key, val, root))
+
+	if _, ok := proof2.(*KeyExistsProof); !ok {
+		require.FailNow("Proof should be *KeyExistsProof")
+	}
 
 	// test with key absent
 	key = []byte{0x38}
@@ -36,10 +39,7 @@ func TestSerializeProofs(t *testing.T) {
 	require.Nil(err, "%+v", err)
 	require.Nil(val)
 	bin = proof.Bytes()
-	// I think this is ugly it works this way, but without type-bytes nothing we can do :(
-	// eproof, err = ReadKeyExistsProof(bin)
-	// require.NotNil(err)
-	aproof, err := ReadKeyAbsentProof(bin)
+	aproof, err := ReadKeyProof(bin)
 	require.Nil(err, "%+v", err)
 	require.NoError(aproof.Verify(key, val, root))
 }

--- a/proof_test.go
+++ b/proof_test.go
@@ -160,6 +160,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 				KeyExistsProof: KeyExistsProof{
 					RootHash:  root,
 					PathToKey: dummyPathToKey(tree, []byte{0x72}),
+					Version:   1,
 				},
 				Left: &pathWithNode{
 					dummyPathToKey(tree, []byte{0x50}),
@@ -192,6 +193,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 				KeyExistsProof: KeyExistsProof{
 					RootHash:  root,
 					PathToKey: dummyPathToKey(tree, []byte{0xf7}),
+					Version:   1,
 				},
 			},
 			expectedError: ErrInvalidInputs,
@@ -206,6 +208,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 				KeyExistsProof: KeyExistsProof{
 					RootHash:  root,
 					PathToKey: dummyPathToKey(tree, []byte{0x0a}),
+					Version:   1,
 				},
 			},
 			expectedError: ErrInvalidInputs,
@@ -220,6 +223,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 				KeyExistsProof: KeyExistsProof{
 					RootHash:  root,
 					PathToKey: dummyPathToKey(tree, []byte{0x11}),
+					Version:   1,
 				},
 				Right: &pathWithNode{
 					Path: dummyPathToKey(tree, []byte{0xf7}),
@@ -237,6 +241,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 			proof: &KeyFirstInRangeProof{
 				KeyExistsProof: KeyExistsProof{
 					RootHash: root,
+					Version:  1,
 				},
 				Left: &pathWithNode{
 					Path: dummyPathToKey(tree, []byte{0xa}),
@@ -259,6 +264,7 @@ func TestTreeKeyFirstInRangeProofsVerify(t *testing.T) {
 				KeyExistsProof: KeyExistsProof{
 					RootHash:  root,
 					PathToKey: dummyPathToKey(tree, []byte{0xa1}),
+					Version:   1,
 				},
 				Left: &pathWithNode{
 					Path: dummyPathToKey(tree, []byte{0xa}),
@@ -549,7 +555,7 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 			keyStart:      []byte{0x0},
 			keyEnd:        []byte{0xff},
 			root:          root,
-			invalidProof:  &KeyRangeProof{RootHash: root},
+			invalidProof:  &KeyRangeProof{RootHash: root, Version: 1},
 			expectedError: ErrInvalidProof,
 		},
 		1: {
@@ -558,7 +564,7 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 			resultKeys:    [][]byte{{0x1}, {0x2}},
 			resultVals:    [][]byte{{0x1}},
 			root:          root,
-			invalidProof:  &KeyRangeProof{RootHash: root},
+			invalidProof:  &KeyRangeProof{RootHash: root, Version: 1},
 			expectedError: ErrInvalidInputs,
 		},
 		2: { // An invalid proof with two adjacent paths which don't prove anything useful.
@@ -882,7 +888,8 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 					dummyPathToKey(tree, []byte{0x2e}),
 					dummyPathToKey(tree, []byte{0x32}),
 				},
-				Right: nil,
+				Right:   nil,
+				Version: 1,
 			},
 			expectedError: ErrInvalidProof,
 		},
@@ -907,6 +914,7 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 					Path: dummyPathToKey(tree, []byte{0x50}),
 					Node: dummyLeafNode([]byte{0x50}, []byte{0x50}),
 				},
+				Version: 1,
 			},
 			expectedError: ErrInvalidProof,
 		},
@@ -933,6 +941,7 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 					Path: dummyPathToKey(tree, []byte{0x50}),
 					Node: dummyLeafNode([]byte{0x50}, []byte{0x50}),
 				},
+				Version: 1,
 			},
 			expectedError: nil,
 		},
@@ -959,6 +968,7 @@ func TestTreeKeyRangeProofVerify(t *testing.T) {
 					Path: dummyPathToKey(tree, []byte{0x50}),
 					Node: dummyLeafNode([]byte{0x50}, []byte{0x50}),
 				},
+				Version: 1,
 			},
 			expectedError: nil,
 		},
@@ -1230,14 +1240,14 @@ func TestKeyAbsentProofVerify(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for i, c := range cases {
 		for _, k := range c.validKeys {
 			err := c.proof.Verify([]byte{k}, nil, c.root)
-			require.NoError(err)
+			require.NoError(err, "Error with case %d: %v", i, err)
 		}
 		for _, k := range c.invalidKeys {
 			err := c.proof.Verify([]byte{k}, nil, c.root)
-			require.Error(err)
+			require.Error(err, "Error with case %d: %v", i, err)
 		}
 	}
 }

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -125,14 +125,14 @@ func testProof(t *testing.T, proof *KeyExistsProof, keyBytes, valueBytes, rootHa
 
 	// Write/Read then verify.
 	proofBytes := proof.Bytes()
-	proof2, err := ReadKeyExistsProof(proofBytes)
+	proof2, err := ReadKeyProof(proofBytes)
 	require.Nil(t, err, "Failed to read KeyExistsProof from bytes: %v", err)
 	require.NoError(t, proof2.Verify(keyBytes, valueBytes, proof.RootHash))
 
 	// Random mutations must not verify
 	for i := 0; i < 10; i++ {
 		badProofBytes := MutateByteSlice(proofBytes)
-		badProof, err := ReadKeyExistsProof(badProofBytes)
+		badProof, err := ReadKeyProof(badProofBytes)
 		// may be invalid... errors are okay
 		if err == nil {
 			assert.Error(t, badProof.Verify(keyBytes, valueBytes, rootHashBytes),

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -24,7 +24,7 @@ func dummyPathToKey(t *Tree, key []byte) *PathToKey {
 }
 
 func dummyLeafNode(key, val []byte) proofLeafNode {
-	return proofLeafNode{key, val, 0}
+	return proofLeafNode{key, val, 1}
 }
 
 func randstr(length int) string {
@@ -48,12 +48,12 @@ func N(l, r interface{}) *Node {
 	if _, ok := l.(*Node); ok {
 		left = l.(*Node)
 	} else {
-		left = NewNode(i2b(l.(int)), nil)
+		left = NewNode(i2b(l.(int)), nil, 0)
 	}
 	if _, ok := r.(*Node); ok {
 		right = r.(*Node)
 	} else {
-		right = NewNode(i2b(r.(int)), nil)
+		right = NewNode(i2b(r.(int)), nil, 0)
 	}
 
 	n := &Node{
@@ -156,17 +156,15 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 
 	b.StopTimer()
 
-	v := int64(1)
 	t := NewVersionedTree(100000, db)
 	for i := 0; i < 1000000; i++ {
 		t.Set(i2b(int(RandInt32())), nil)
 		if i > 990000 && i%1000 == 999 {
-			t.SaveVersion(v)
-			v++
+			t.SaveVersion()
 		}
 	}
 	b.ReportAllocs()
-	t.SaveVersion(v)
+	t.SaveVersion()
 
 	fmt.Println("ok, starting")
 
@@ -178,8 +176,7 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 		t.Set(ri, nil)
 		t.Remove(ri)
 		if i%100 == 99 {
-			t.SaveVersion(v)
-			v++
+			t.SaveVersion()
 		}
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -76,7 +76,7 @@ func (t *Tree) set(key []byte, value []byte) (orphaned []*Node, updated bool) {
 		cmn.PanicSanity(cmn.Fmt("Attempt to store nil value at key '%s'", key))
 	}
 	if t.root == nil {
-		t.root = NewNode(key, value, 1)
+		t.root = NewNode(key, value, t.version+1)
 		return nil, false
 	}
 	t.root, updated, orphaned = t.root.set(t, key, value)

--- a/tree.go
+++ b/tree.go
@@ -10,7 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Tree is an immutable AVL+ Tree. Note that this tree is not thread-safe.
+// Tree is a container for an immutable AVL+ Tree. Changes are performed by
+// swapping the internal root with a new one, while the container is mutable.
+// Note that this tree is not thread-safe.
 type Tree struct {
 	root    *Node
 	ndb     *nodeDB

--- a/tree.go
+++ b/tree.go
@@ -219,13 +219,13 @@ func (t *Tree) IterateRangeInclusive(start, end []byte, ascending bool, fn func(
 	})
 }
 
-// Clone creates a clone of the tree and increments its version.
+// Clone creates a clone of the tree.
 // Used internally by VersionedTree.
 func (tree *Tree) clone() *Tree {
 	return &Tree{
 		root:    tree.root,
 		ndb:     tree.ndb,
-		version: tree.version + 1,
+		version: tree.version,
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -17,7 +17,7 @@ type Tree struct {
 	version int64
 }
 
-// NewTree creates both im-memory and persistent instances
+// NewTree creates both in-memory and persistent instances
 func NewTree(cacheSize int, db dbm.DB) *Tree {
 	if db == nil {
 		// In-memory Tree.

--- a/tree_fuzz_test.go
+++ b/tree_fuzz_test.go
@@ -64,7 +64,7 @@ func (i instruction) Execute(tree *VersionedTree) {
 	case "REMOVE":
 		tree.Remove(i.k)
 	case "SAVE":
-		tree.SaveVersion(i.version)
+		tree.SaveVersion()
 	case "DELETE":
 		tree.DeleteVersion(i.version)
 	default:

--- a/tree_test.go
+++ b/tree_test.go
@@ -924,20 +924,17 @@ func TestVersionedTreeProofs(t *testing.T) {
 	require.Nil(val)
 	require.NoError(proof.Verify([]byte("k4"), nil, root1))
 	require.Error(proof.Verify([]byte("k4"), val, root2))
-	require.EqualValues(1, proof.(*KeyAbsentProof).Version)
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k2"), 2)
 	require.NoError(err)
 	require.EqualValues(val, []byte("v2"))
 	require.NoError(proof.Verify([]byte("k2"), val, root2))
 	require.Error(proof.Verify([]byte("k2"), val, root1))
-	require.EqualValues(2, proof.(*KeyExistsProof).Version)
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k1"), 2)
 	require.NoError(err)
 	require.EqualValues(val, []byte("v1"))
 	require.NoError(proof.Verify([]byte("k1"), val, root2))
-	require.EqualValues(1, proof.(*KeyExistsProof).Version) // Key version = 1
 
 	val, proof, err = tree.GetVersionedWithProof([]byte("k2"), 3)
 	require.NoError(err)
@@ -945,7 +942,6 @@ func TestVersionedTreeProofs(t *testing.T) {
 	require.NoError(proof.Verify([]byte("k2"), nil, root3))
 	require.Error(proof.Verify([]byte("k2"), nil, root1))
 	require.Error(proof.Verify([]byte("k2"), nil, root2))
-	require.EqualValues(1, proof.(*KeyAbsentProof).Version)
 }
 
 func TestVersionedTreeHash(t *testing.T) {

--- a/versioned_tree.go
+++ b/versioned_tree.go
@@ -161,9 +161,6 @@ func (tree *VersionedTree) SaveVersion() ([]byte, int64, error) {
 	if _, ok := tree.versions[version]; ok {
 		return nil, version, errors.Errorf("version %d was already saved", version)
 	}
-	if tree.root == nil {
-		return nil, 0, ErrNilRoot
-	}
 
 	tree.latestVersion = version
 	tree.versions[version] = tree.orphaningTree.Tree
@@ -173,9 +170,9 @@ func (tree *VersionedTree) SaveVersion() ([]byte, int64, error) {
 		tree.versions[version].clone(),
 	)
 
-	tree.ndb.SaveRoot(tree.root, version)
-	tree.ndb.Commit()
-
+	if tree.root == nil {
+		return nil, version, nil
+	}
 	return tree.root.hash, version, nil
 }
 

--- a/versioned_tree.go
+++ b/versioned_tree.go
@@ -93,7 +93,7 @@ func (tree *VersionedTree) LoadVersion(version int64) error {
 		if v > version {
 			continue
 		}
-		t := &Tree{ndb: tree.ndb}
+		t := &Tree{ndb: tree.ndb, version: v}
 		t.load(root)
 
 		tree.versions[v] = t
@@ -116,7 +116,7 @@ func (tree *VersionedTree) Load() error {
 
 	// Load all roots from the database.
 	for version, root := range roots {
-		t := &Tree{ndb: tree.ndb}
+		t := &Tree{ndb: tree.ndb, version: version}
 		t.load(root)
 
 		tree.versions[version] = t
@@ -139,7 +139,7 @@ func (tree *VersionedTree) ResetToLatest() {
 			tree.versions[tree.latestVersion].clone(),
 		)
 	} else {
-		tree.orphaningTree = newOrphaningTree(&Tree{ndb: tree.ndb})
+		tree.orphaningTree = newOrphaningTree(&Tree{ndb: tree.ndb, version: 0})
 	}
 }
 
@@ -154,26 +154,21 @@ func (tree *VersionedTree) GetVersioned(key []byte, version int64) (
 }
 
 // SaveVersion saves a new tree version to disk, based on the current state of
-// the tree. Multiple calls to SaveVersion with the same version are not allowed.
-func (tree *VersionedTree) SaveVersion(version int64) ([]byte, error) {
+// the tree. Returns the hash and new version number.
+func (tree *VersionedTree) SaveVersion() ([]byte, int64, error) {
+	version := tree.latestVersion + 1
+
 	if _, ok := tree.versions[version]; ok {
-		return nil, errors.Errorf("version %d was already saved", version)
+		return nil, version, errors.Errorf("version %d was already saved", version)
 	}
 	if tree.root == nil {
-		return nil, ErrNilRoot
-	}
-	if version == 0 {
-		return nil, errors.New("version must be greater than zero")
-	}
-	if version <= tree.latestVersion {
-		return nil, errors.Errorf("version must be greater than latest (%d <= %d)",
-			version, tree.latestVersion)
+		return nil, 0, ErrNilRoot
 	}
 
 	tree.latestVersion = version
 	tree.versions[version] = tree.orphaningTree.Tree
 
-	tree.orphaningTree.SaveVersion(version)
+	tree.orphaningTree.Save()
 	tree.orphaningTree = newOrphaningTree(
 		tree.versions[version].clone(),
 	)
@@ -181,7 +176,7 @@ func (tree *VersionedTree) SaveVersion(version int64) ([]byte, error) {
 	tree.ndb.SaveRoot(tree.root, version)
 	tree.ndb.Commit()
 
-	return tree.root.hash, nil
+	return tree.root.hash, version, nil
 }
 
 // DeleteVersion deletes a tree version from disk. The version can then no

--- a/versioned_tree.go
+++ b/versioned_tree.go
@@ -168,7 +168,7 @@ func (tree *VersionedTree) SaveVersion() ([]byte, int64, error) {
 	tree.latestVersion = version
 	tree.versions[version] = tree.orphaningTree.Tree
 
-	tree.orphaningTree.Save()
+	tree.orphaningTree.SaveAs(version)
 	tree.orphaningTree = newOrphaningTree(
 		tree.versions[version].clone(),
 	)


### PR DESCRIPTION
This changes the API for saving versions from:
```
SaveVersion(version int64) (hash []byte, err error)
```

to

```
SaveVersion() (hash []byte, version int64, err error)
```

Where the new `SaveVersion` auto-increments the version, starting from 1.