### PR TITLE
WIP: cachewrap on iavl tree

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,90 @@
+package iavl
+
+import (
+	dbm "github.com/tendermint/tmlibs/db"
+)
+
+type CachedTree struct {
+	// this is the parent to write to
+	parent *Tree
+
+	// this is the cache tree we expose
+	*Tree
+}
+
+// CacheWrap clones this tree with a different
+// backing database
+func (t *Tree) CacheWrap() *CachedTree {
+	// ndb := newNodeDB(t.ndb.nodeCacheSize, t.ndb.db.CacheDB())
+	cache := &Tree{
+		root: t.root,
+		ndb:  t.ndb.Cache(),
+	}
+
+	return &CachedTree{
+		parent: t,
+		Tree:   cache,
+	}
+
+}
+
+// Write writes pending updates to the parent database
+// and clears the cache - meant for cachedbs...
+func (c *CachedTree) Write() error {
+	// TODO: some sort of checks and balances...
+	c.parent.root = c.root
+	// this will write our cached batch to the parent batch
+	c.Tree.ndb.Commit()
+	return nil
+}
+
+func (n *nodeDB) Cache() *nodeDB {
+	// make a shallow copy, reuse cache, etc.
+	cacheDB := *n
+	// create a new batch
+	cacheDB.batch = &cacheBatch{parent: cacheDB.batch}
+	return &cacheDB
+}
+
+/////////////////////////////////////////////////
+// cacheBatch
+
+// no concurrency please (but fine for abci apps)
+type cacheBatch struct {
+	parent dbm.Batch
+	ops    []operation
+}
+
+var _ dbm.Batch = (*cacheBatch)(nil)
+
+type opType int
+
+const (
+	opTypeSet    opType = 1
+	opTypeDelete opType = 2
+)
+
+type operation struct {
+	opType
+	key   []byte
+	value []byte
+}
+
+func (cb *cacheBatch) Set(key, value []byte) {
+	cb.ops = append(cb.ops, operation{opTypeSet, key, value})
+}
+
+func (cb *cacheBatch) Delete(key []byte) {
+	cb.ops = append(cb.ops, operation{opTypeDelete, key, nil})
+}
+
+func (cb *cacheBatch) Write() {
+	for _, op := range cb.ops {
+		switch op.opType {
+		case opTypeSet:
+			cb.parent.Set(op.key, op.value)
+		case opTypeDelete:
+			cb.parent.Delete(op.key)
+		}
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -17,7 +17,7 @@ func randomData(vt *VersionedTree, versions, keysPerVersion int) {
 	}
 }
 
-func TestCachedVersionTree(t *testing.T) {
+func TestCacheWrapVersionTree(t *testing.T) {
 	require := rqr.New(t)
 
 	d, closeDB := getTestDB()
@@ -79,6 +79,82 @@ func TestCachedVersionTree(t *testing.T) {
 	tree.SaveVersion(working)
 	newTree := NewVersionedTree(100, d)
 	err = newTree.LoadVersion(working)
+	require.NoError(err)
+	loaded := newTree.Tree()
+
+	_, vr = loaded.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = loaded.Get(k)
+	require.Nil(vr)
+	reload := loaded.Hash()
+	require.Equal(chash, reload)
+}
+
+// TestCacheWrapVersionTree is same as above, but with Cache
+// to demonstrate it works the same, but reuses the Tree struct
+func TestCacheVersionTree(t *testing.T) {
+	require := rqr.New(t)
+
+	d, closeDB := getTestDB()
+	defer closeDB()
+
+	tree := NewVersionedTree(100, d)
+	versions := 50
+	keysPerVersion := 30
+	randomData(tree, versions, keysPerVersion)
+
+	// let's calculate the root first
+	tip := tree.Tree()
+	saved := tip.Hash()
+
+	// set one data and show it updates proper like
+	k, v := randBytes(8), randBytes(8)
+	tip.Set(k, v)
+	_, vr := tip.Get(k)
+	require.Equal(v, vr)
+	update := tip.Hash()
+	require.NotEqual(saved, update)
+
+	// be clear this must be a *Tree
+	var cache *Tree
+	cache = tip.Cache()
+	k2, v2 := randBytes(8), randBytes(8)
+	cache.Set(k2, v2)
+	cache.Remove(k)
+
+	// must only affect the cache
+	_, vr = cache.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = cache.Get(k)
+	require.Nil(vr)
+	chash := cache.Hash()
+	require.NotEqual(update, chash)
+
+	// note that tip is not affected
+	_, vr = tip.Get(k)
+	require.Equal(v, vr)
+	_, vr = tip.Get(k2)
+	require.Nil(vr)
+	uncached := tip.Hash()
+	require.Equal(update, uncached)
+
+	// write cache by committing batch
+	// (TODO: this must be public)
+	cache.ndb.Commit()
+
+	// show tip affected
+	_, vr = tip.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = tip.Get(k)
+	require.Nil(vr)
+	after := tip.Hash()
+	require.Equal(chash, after)
+
+	// save to disk, reload must show cached data
+	working := int64(versions + 1)
+	tree.SaveVersion(working)
+	newTree := NewVersionedTree(100, d)
+	err := newTree.LoadVersion(working)
 	require.NoError(err)
 	loaded := newTree.Tree()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,91 @@
+package iavl
+
+import (
+	"testing"
+
+	rqr "github.com/stretchr/testify/require"
+)
+
+func randomData(vt *VersionedTree, versions, keysPerVersion int) {
+	for i := 1; i <= versions; i++ {
+		for j := 0; j < keysPerVersion; j++ {
+			k := randBytes(8)
+			v := randBytes(8)
+			vt.Set(k, v)
+		}
+		vt.SaveVersion(int64(i))
+	}
+}
+
+func TestCachedVersionTree(t *testing.T) {
+	require := rqr.New(t)
+
+	d, closeDB := getTestDB()
+	defer closeDB()
+
+	tree := NewVersionedTree(100, d)
+	versions := 50
+	keysPerVersion := 30
+	randomData(tree, versions, keysPerVersion)
+
+	// let's calculate the root first
+	tip := tree.Tree()
+	saved := tip.Hash()
+
+	// set one data and show it updates proper like
+	k, v := randBytes(8), randBytes(8)
+	tip.Set(k, v)
+	_, vr := tip.Get(k)
+	require.Equal(v, vr)
+	update := tip.Hash()
+	require.NotEqual(saved, update)
+
+	// try various options on a cache
+	cache := tip.CacheWrap()
+	k2, v2 := randBytes(8), randBytes(8)
+	cache.Set(k2, v2)
+	cache.Remove(k)
+
+	// must only affect the cache
+	_, vr = cache.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = cache.Get(k)
+	require.Nil(vr)
+	chash := cache.Hash()
+	require.NotEqual(update, chash)
+
+	// note that tip is not affected
+	_, vr = tip.Get(k)
+	require.Equal(v, vr)
+	_, vr = tip.Get(k2)
+	require.Nil(vr)
+	uncached := tip.Hash()
+	require.Equal(update, uncached)
+
+	// write cache
+	err := cache.Write()
+	require.NoError(err)
+
+	// show tip affected
+	_, vr = tip.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = tip.Get(k)
+	require.Nil(vr)
+	after := tip.Hash()
+	require.Equal(chash, after)
+
+	// save to disk, reload must show cached data
+	working := int64(versions + 1)
+	tree.SaveVersion(working)
+	newTree := NewVersionedTree(100, d)
+	err = newTree.LoadVersion(working)
+	require.NoError(err)
+	loaded := newTree.Tree()
+
+	_, vr = loaded.Get(k2)
+	require.Equal(v2, vr)
+	_, vr = loaded.Get(k)
+	require.Nil(vr)
+	reload := loaded.Hash()
+	require.Equal(chash, reload)
+}

--- a/nodedb.go
+++ b/nodedb.go
@@ -61,6 +61,12 @@ func newNodeDB(cacheSize int, db dbm.DB) *nodeDB {
 	return ndb
 }
 
+// make a shallow copy, reuse cache, etc.
+func (n *nodeDB) clone() *nodeDB {
+	cacheDB := *n
+	return &cacheDB
+}
+
 // GetNode gets a node from cache or disk. If it is an inner node, it does not
 // load its children.
 func (ndb *nodeDB) GetNode(hash []byte) *Node {


### PR DESCRIPTION
To efficiently implement caching on top over iavl including with range queries, we cannot add a layer outside of iavl, but need support inside of it. This is a requirement for the rewrite of cosmos-sdk.

I implement a CachedTree that performs this task straightforward, but is not a Tree, so cannot be used interchangably. This is created with `CacheWrap()`

I also implement a second approach that is transparently a tree, but may have a bit too much magic under the hood for some people. This is created with `Cache()`.

Please provide feedback on how to evolve this.