### PR TITLE
Sdk2 cloneversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 vendor
 .glide
+*.swp
+*.swo
 
 # created in test code
 test.db

--- a/basic_test.go
+++ b/basic_test.go
@@ -32,7 +32,7 @@ func TestBasic(t *testing.T) {
 
 	// Test 0x00
 	{
-		idx, val := tree.Get([]byte{0x00})
+		idx, val := tree.Get64([]byte{0x00})
 		if val != nil {
 			t.Errorf("Expected no value to exist")
 		}
@@ -46,7 +46,7 @@ func TestBasic(t *testing.T) {
 
 	// Test "1"
 	{
-		idx, val := tree.Get([]byte("1"))
+		idx, val := tree.Get64([]byte("1"))
 		if val == nil {
 			t.Errorf("Expected value to exist")
 		}
@@ -60,7 +60,7 @@ func TestBasic(t *testing.T) {
 
 	// Test "2"
 	{
-		idx, val := tree.Get([]byte("2"))
+		idx, val := tree.Get64([]byte("2"))
 		if val == nil {
 			t.Errorf("Expected value to exist")
 		}
@@ -74,7 +74,7 @@ func TestBasic(t *testing.T) {
 
 	// Test "4"
 	{
-		idx, val := tree.Get([]byte("4"))
+		idx, val := tree.Get64([]byte("4"))
 		if val != nil {
 			t.Errorf("Expected no value to exist")
 		}
@@ -88,7 +88,7 @@ func TestBasic(t *testing.T) {
 
 	// Test "6"
 	{
-		idx, val := tree.Get([]byte("6"))
+		idx, val := tree.Get64([]byte("6"))
 		if val != nil {
 			t.Errorf("Expected no value to exist")
 		}
@@ -103,7 +103,7 @@ func TestBasic(t *testing.T) {
 
 func TestUnit(t *testing.T) {
 
-	expectHash := func(tree *Tree, hashCount int) {
+	expectHash := func(tree *Tree, hashCount int64) {
 		// ensure number of new hash calculations is as expected.
 		hash, count := tree.hashWithCount()
 		if count != hashCount {
@@ -121,7 +121,7 @@ func TestUnit(t *testing.T) {
 		}
 	}
 
-	expectSet := func(tree *Tree, i int, repr string, hashCount int) {
+	expectSet := func(tree *Tree, i int, repr string, hashCount int64) {
 		origNode := tree.root
 		updated := tree.Set(i2b(i), []byte{})
 		// ensure node was added & structure is as expected.
@@ -134,7 +134,7 @@ func TestUnit(t *testing.T) {
 		tree.root = origNode
 	}
 
-	expectRemove := func(tree *Tree, i int, repr string, hashCount int) {
+	expectRemove := func(tree *Tree, i int, repr string, hashCount int64) {
 		origNode := tree.root
 		value, removed := tree.Remove(i2b(i))
 		// ensure node was added & structure is as expected.
@@ -249,7 +249,7 @@ func TestIntegration(t *testing.T) {
 		if has := tree.Has([]byte(randstr(12))); has {
 			t.Error("Table has extra key")
 		}
-		if _, val := tree.Get([]byte(r.key)); string(val) != string(r.value) {
+		if _, val := tree.Get64([]byte(r.key)); string(val) != string(r.value) {
 			t.Error("wrong value")
 		}
 	}
@@ -267,7 +267,7 @@ func TestIntegration(t *testing.T) {
 			if has := tree.Has([]byte(randstr(12))); has {
 				t.Error("Table has extra key")
 			}
-			_, val := tree.Get([]byte(r.key))
+			_, val := tree.Get64([]byte(r.key))
 			if string(val) != string(r.value) {
 				t.Error("wrong value")
 			}
@@ -379,7 +379,7 @@ func TestPersistence(t *testing.T) {
 	t2 := NewVersionedTree(0, db)
 	t2.Load()
 	for key, value := range records {
-		_, t2value := t2.Get([]byte(key))
+		_, t2value := t2.Get64([]byte(key))
 		if string(t2value) != value {
 			t.Fatalf("Invalid value. Expected %v, got %v", value, t2value)
 		}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,11 @@
+package iavl
+
+import (
+	"fmt"
+)
+
+func debug(format string, args ...interface{}) {
+	if false {
+		fmt.Printf(format, args...)
+	}
+}

--- a/node.go
+++ b/node.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/crypto/ripemd160"
 
 	"github.com/tendermint/go-wire"
-	cmn "github.com/tendermint/tmlibs/common"
 )
 
 // Node represents a node in a Tree.
@@ -102,7 +101,7 @@ func (node *Node) String() string {
 // clone creates a shallow copy of a node with its hash set to nil.
 func (node *Node) clone(version int64) *Node {
 	if node.isLeaf() {
-		cmn.PanicSanity("Attempt to copy a leaf node")
+		panic("Attempt to copy a leaf node")
 	}
 	return &Node{
 		key:       node.key,
@@ -189,7 +188,7 @@ func (node *Node) _hash() []byte {
 	hasher := ripemd160.New()
 	buf := new(bytes.Buffer)
 	if _, err := node.writeHashBytes(buf); err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 	hasher.Write(buf.Bytes())
 	node.hash = hasher.Sum(nil)
@@ -208,7 +207,7 @@ func (node *Node) hashWithCount() ([]byte, int64) {
 	buf := new(bytes.Buffer)
 	_, hashCount, err := node.writeHashBytesRecursively(buf)
 	if err != nil {
-		cmn.PanicCrisis(err)
+		panic(err)
 	}
 	hasher.Write(buf.Bytes())
 	node.hash = hasher.Sum(nil)
@@ -230,7 +229,7 @@ func (node *Node) writeHashBytes(w io.Writer) (n int, err error) {
 		wire.WriteByteSlice(node.value, w, &n, &err)
 	} else {
 		if node.leftHash == nil || node.rightHash == nil {
-			cmn.PanicSanity("Found an empty child hash")
+			panic("Found an empty child hash")
 		}
 		wire.WriteByteSlice(node.leftHash, w, &n, &err)
 		wire.WriteByteSlice(node.rightHash, w, &n, &err)
@@ -269,12 +268,12 @@ func (node *Node) writeBytes(w io.Writer) (n int, err error) {
 		wire.WriteByteSlice(node.value, w, &n, &err)
 	} else {
 		if node.leftHash == nil {
-			cmn.PanicSanity("node.leftHash was nil in writeBytes")
+			panic("node.leftHash was nil in writeBytes")
 		}
 		wire.WriteByteSlice(node.leftHash, w, &n, &err)
 
 		if node.rightHash == nil {
-			cmn.PanicSanity("node.rightHash was nil in writeBytes")
+			panic("node.rightHash was nil in writeBytes")
 		}
 		wire.WriteByteSlice(node.rightHash, w, &n, &err)
 	}

--- a/nodedb.go
+++ b/nodedb.go
@@ -369,7 +369,7 @@ func (ndb *nodeDB) saveRoot(hash []byte, version int64) error {
 	defer ndb.mtx.Unlock()
 
 	if version != ndb.getLatestVersion()+1 {
-		return errors.New("can't save root with lower or equal version than latest")
+		return fmt.Errorf("Must save consecutive versions. Expected %d, got %d", ndb.getLatestVersion()+1, version)
 	}
 
 	key := ndb.rootKey(version)

--- a/orphaning_tree.go
+++ b/orphaning_tree.go
@@ -73,12 +73,3 @@ func (tree *orphaningTree) addOrphans(orphans []*Node) {
 		tree.orphans[string(node.hash)] = node.version
 	}
 }
-
-// Drop an orphan from the orphan list. Doesn't write to disk.
-func (tree *orphaningTree) dropOrphan(hash []byte) (version int64, dropped bool) {
-	if version, ok := tree.orphans[string(hash)]; ok {
-		delete(tree.orphans, string(hash))
-		return version, true
-	}
-	return 0, false
-}

--- a/orphaning_tree.go
+++ b/orphaning_tree.go
@@ -1,6 +1,8 @@
 package iavl
 
 import (
+	"fmt"
+
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -36,34 +38,26 @@ func (tree *orphaningTree) Remove(key []byte) ([]byte, bool) {
 	return val, removed
 }
 
-// Unorphan undoes the orphaning of a node, removing the orphan entry on disk
-// if necessary.
-func (tree *orphaningTree) unorphan(hash []byte) {
-	tree.deleteOrphan(hash)
-	tree.ndb.Unorphan(hash)
-}
-
 // SaveAs saves the underlying Tree and assigns it a new version.
 // Saves orphans too.
 func (tree *orphaningTree) SaveAs(version int64) {
+	if version != tree.version+1 {
+		panic(fmt.Sprintf("Expected to save version %d but tried to save %d", tree.version+1, version))
+	}
 	if tree.root == nil {
 		// There can still be orphans, for example if the root is the node being
 		// removed.
-		tree.ndb.SaveOrphans(tree.version, tree.orphans)
+		tree.ndb.SaveOrphans(version, tree.orphans)
 		tree.ndb.SaveEmptyRoot(version)
 	} else {
-		// Save the current tree. For each saved node, we delete any existing
-		// orphan entries in the previous trees.  This is necessary because
-		// sometimes tree re-balancing causes nodes to be incorrectly marked as
-		// orphaned, since tree patterns after a re-balance may mirror previous
-		// tree patterns, with matching hashes.
-		tree.ndb.SaveBranch(tree.root, func(node *Node) {
-			tree.unorphan(node._hash())
-		})
-		tree.ndb.SaveOrphans(tree.version, tree.orphans)
+		debug("SAVE TREE %v\n", version)
+		// Save the current tree.
+		tree.ndb.SaveBranch(tree.root)
+		tree.ndb.SaveOrphans(version, tree.orphans)
 		tree.ndb.SaveRoot(tree.root, version)
 	}
 	tree.ndb.Commit()
+	tree.version = version
 }
 
 // Add orphans to the orphan list. Doesn't write to disk.
@@ -80,8 +74,8 @@ func (tree *orphaningTree) addOrphans(orphans []*Node) {
 	}
 }
 
-// Delete an orphan from the orphan list. Doesn't write to disk.
-func (tree *orphaningTree) deleteOrphan(hash []byte) (version int64, deleted bool) {
+// Drop an orphan from the orphan list. Doesn't write to disk.
+func (tree *orphaningTree) dropOrphan(hash []byte) (version int64, dropped bool) {
 	if version, ok := tree.orphans[string(hash)]; ok {
 		delete(tree.orphans, string(hash))
 		return version, true

--- a/orphaning_tree.go
+++ b/orphaning_tree.go
@@ -2,8 +2,6 @@ package iavl
 
 import (
 	"fmt"
-
-	cmn "github.com/tendermint/tmlibs/common"
 )
 
 // orphaningTree is a tree which keeps track of orphaned nodes.
@@ -68,7 +66,7 @@ func (tree *orphaningTree) addOrphans(orphans []*Node) {
 			continue
 		}
 		if len(node.hash) == 0 {
-			cmn.PanicSanity("Expected to find node hash, but was empty")
+			panic("Expected to find node hash, but was empty")
 		}
 		tree.orphans[string(node.hash)] = node.version
 	}

--- a/proof.go
+++ b/proof.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/go-wire/data"
-	cmn "github.com/tendermint/tmlibs/common"
 )
 
 var (
@@ -55,7 +54,7 @@ func (branch proofInnerNode) Hash(childHash []byte) []byte {
 		wire.WriteByteSlice(childHash, buf, &n, &err)
 	}
 	if err != nil {
-		cmn.PanicCrisis(cmn.Fmt("Failed to hash proofInnerNode: %v", err))
+		panic(fmt.Sprintf("Failed to hash proofInnerNode: %v", err))
 	}
 	hasher.Write(buf.Bytes())
 
@@ -80,7 +79,7 @@ func (leaf proofLeafNode) Hash() []byte {
 	wire.WriteByteSlice(leaf.ValueBytes, buf, &n, &err)
 
 	if err != nil {
-		cmn.PanicCrisis(cmn.Fmt("Failed to hash proofLeafNode: %v", err))
+		panic(fmt.Sprintf("Failed to hash proofLeafNode: %v", err))
 	}
 	hasher.Write(buf.Bytes())
 

--- a/proof_range.go
+++ b/proof_range.go
@@ -298,8 +298,8 @@ func (t *Tree) getRangeWithProof(keyStart, keyEnd []byte, limit int) (
 	if needsLeft {
 		// Find index of first key to the left, and include proof if it isn't the
 		// leftmost key.
-		if idx, _ := t.Get(rangeStart); idx > 0 {
-			lkey, lval := t.GetByIndex(idx - 1)
+		if idx, _ := t.Get64(rangeStart); idx > 0 {
+			lkey, lval := t.GetByIndex64(idx - 1)
 			path, node, _ := t.root.pathToKey(t, lkey)
 			rangeProof.Left = &pathWithNode{
 				Path: path,
@@ -314,8 +314,8 @@ func (t *Tree) getRangeWithProof(keyStart, keyEnd []byte, limit int) (
 	if needsRight {
 		// Find index of first key to the right, and include proof if it isn't the
 		// rightmost key.
-		if idx, _ := t.Get(rangeEnd); idx <= t.Size()-1 {
-			rkey, rval := t.GetByIndex(idx)
+		if idx, _ := t.Get64(rangeEnd); idx <= t.Size64()-1 {
+			rkey, rval := t.GetByIndex64(idx)
 			path, node, _ := t.root.pathToKey(t, rkey)
 			rangeProof.Right = &pathWithNode{
 				Path: path,
@@ -349,8 +349,8 @@ func (t *Tree) getFirstInRangeWithProof(keyStart, keyEnd []byte) (
 	}
 
 	if !bytes.Equal(key, keyStart) {
-		if idx, _ := t.Get(keyStart); idx-1 >= 0 && idx-1 <= t.Size()-1 {
-			k, v := t.GetByIndex(idx - 1)
+		if idx, _ := t.Get64(keyStart); idx-1 >= 0 && idx-1 <= t.Size64()-1 {
+			k, v := t.GetByIndex64(idx - 1)
 			path, node, _ := t.root.pathToKey(t, k)
 			proof.Left = &pathWithNode{
 				Path: path,
@@ -360,8 +360,8 @@ func (t *Tree) getFirstInRangeWithProof(keyStart, keyEnd []byte) (
 	}
 
 	if !bytes.Equal(key, keyEnd) {
-		if idx, val := t.Get(keyEnd); idx <= t.Size()-1 && val == nil {
-			k, v := t.GetByIndex(idx)
+		if idx, val := t.Get64(keyEnd); idx <= t.Size64()-1 && val == nil {
+			k, v := t.GetByIndex64(idx)
 			path, node, _ := t.root.pathToKey(t, k)
 			proof.Right = &pathWithNode{
 				Path: path,
@@ -396,8 +396,8 @@ func (t *Tree) getLastInRangeWithProof(keyStart, keyEnd []byte) (
 	}
 
 	if !bytes.Equal(key, keyEnd) {
-		if idx, _ := t.Get(keyEnd); idx <= t.Size()-1 {
-			k, v := t.GetByIndex(idx)
+		if idx, _ := t.Get64(keyEnd); idx <= t.Size64()-1 {
+			k, v := t.GetByIndex64(idx)
 			path, node, _ := t.root.pathToKey(t, k)
 			proof.Right = &pathWithNode{
 				Path: path,
@@ -407,8 +407,8 @@ func (t *Tree) getLastInRangeWithProof(keyStart, keyEnd []byte) (
 	}
 
 	if !bytes.Equal(key, keyStart) {
-		if idx, _ := t.Get(keyStart); idx-1 >= 0 && idx-1 <= t.Size()-1 {
-			k, v := t.GetByIndex(idx - 1)
+		if idx, _ := t.Get64(keyStart); idx-1 >= 0 && idx-1 <= t.Size64()-1 {
+			k, v := t.GetByIndex64(idx - 1)
 			path, node, _ := t.root.pathToKey(t, k)
 			proof.Left = &pathWithNode{
 				Path: path,

--- a/tree.go
+++ b/tree.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	cmn "github.com/tendermint/tmlibs/common"
 	dbm "github.com/tendermint/tmlibs/db"
 
 	"github.com/pkg/errors"
@@ -90,7 +89,7 @@ func (t *Tree) Set(key []byte, value []byte) (updated bool) {
 
 func (t *Tree) set(key []byte, value []byte) (orphaned []*Node, updated bool) {
 	if value == nil {
-		cmn.PanicSanity(cmn.Fmt("Attempt to store nil value at key '%s'", key))
+		panic(fmt.Sprintf("Attempt to store nil value at key '%s'", key))
 	}
 	if t.root == nil {
 		t.root = NewNode(key, value, t.version+1)

--- a/tree.go
+++ b/tree.go
@@ -43,14 +43,31 @@ func (t *Tree) String() string {
 
 // Size returns the number of leaf nodes in the tree.
 func (t *Tree) Size() int {
+	return int(t.Size64())
+}
+
+func (t *Tree) Size64() int64 {
 	if t.root == nil {
 		return 0
 	}
 	return t.root.size
 }
 
+// Version returns the version of the tree.
+func (t *Tree) Version() int {
+	return int(t.Version64())
+}
+
+func (t *Tree) Version64() int64 {
+	return t.version
+}
+
 // Height returns the height of the tree.
-func (t *Tree) Height() int8 {
+func (t *Tree) Height() int {
+	return int(t.Height8())
+}
+
+func (t *Tree) Height8() int8 {
 	if t.root == nil {
 		return 0
 	}
@@ -94,7 +111,7 @@ func (t *Tree) Hash() []byte {
 }
 
 // hashWithCount returns the root hash and hash count.
-func (t *Tree) hashWithCount() ([]byte, int) {
+func (t *Tree) hashWithCount() ([]byte, int64) {
 	if t.root == nil {
 		return nil, 0
 	}
@@ -104,6 +121,11 @@ func (t *Tree) hashWithCount() ([]byte, int) {
 // Get returns the index and value of the specified key if it exists, or nil
 // and the next index, if it doesn't.
 func (t *Tree) Get(key []byte) (index int, value []byte) {
+	index64, value := t.Get64(key)
+	return int(index64), value
+}
+
+func (t *Tree) Get64(key []byte) (index int64, value []byte) {
 	if t.root == nil {
 		return 0, nil
 	}
@@ -112,6 +134,10 @@ func (t *Tree) Get(key []byte) (index int, value []byte) {
 
 // GetByIndex gets the key and value at the specified index.
 func (t *Tree) GetByIndex(index int) (key []byte, value []byte) {
+	return t.GetByIndex64(int64(index))
+}
+
+func (t *Tree) GetByIndex64(index int64) (key []byte, value []byte) {
 	if t.root == nil {
 		return nil, nil
 	}
@@ -233,12 +259,13 @@ func (tree *Tree) clone() *Tree {
 
 // Load the tree from disk, from the given root hash, including all orphans.
 // Used internally by VersionedTree.
-func (tree *Tree) load(root []byte) {
+func (tree *Tree) load(version int64, root []byte) {
 	if len(root) == 0 {
 		tree.root = nil
 		return
 	}
 	tree.root = tree.ndb.GetNode(root)
+	tree.version = version
 }
 
 // nodeSize is like Size, but includes inner nodes too.

--- a/tree.go
+++ b/tree.go
@@ -264,6 +264,10 @@ func (tree *Tree) load(version int64, root []byte) {
 		return
 	}
 	tree.root = tree.ndb.GetNode(root)
+
+	// This is wrong.  When saving a tree w/o updates, the tree's root node's
+	// version gets stale.
+	// tree.version = tree.root.version
 	tree.version = version
 }
 


### PR DESCRIPTION
Correctly sets inner node versions.
Incorporates the inner node version in its hash.
Remove orphanIndex logic.