### PR TITLE
Revert "Improve serializer"

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,185 @@
+package iavl
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+	cmn "github.com/tendermint/tmlibs/common"
+)
+
+// Chunk is a list of ordered nodes.
+// It can be sorted, merged, exported from a tree and
+// used to generate a new tree.
+type Chunk []OrderedNodeData
+
+// OrderedNodeData is the data to recreate a leaf node,
+// along with a SortOrder to define a BFS insertion order.
+type OrderedNodeData struct {
+	SortOrder uint64
+	NodeData
+}
+
+// NewOrderedNode creates the data from a leaf node.
+func NewOrderedNode(leaf *Node, prefix uint64) OrderedNodeData {
+	return OrderedNodeData{
+		SortOrder: prefix,
+		NodeData: NodeData{
+			Key:   leaf.key,
+			Value: leaf.value,
+		},
+	}
+}
+
+// getChunkHashes returns all the "checksum" hashes for
+// the chunks that will be sent.
+func getChunkHashes(tree *Tree, depth uint) ([][]byte, [][]byte, uint, error) {
+	maxDepth := uint(tree.root.height / 2)
+	if depth > maxDepth {
+		return nil, nil, 0, errors.New("depth exceeds maximum allowed")
+	}
+
+	nodes := getNodes(tree, depth)
+	hashes := make([][]byte, len(nodes))
+	keys := make([][]byte, len(nodes))
+	for i, n := range nodes {
+		hashes[i] = n.hash
+		keys[i] = n.key
+	}
+	return hashes, keys, depth, nil
+}
+
+// GetChunkHashesWithProofs takes a tree and returns the list of chunks with
+// proofs that can be used to synchronize a tree across the network.
+func GetChunkHashesWithProofs(tree *Tree) ([][]byte, []*InnerKeyProof, uint) {
+	hashes, keys, depth, err := getChunkHashes(tree, uint(tree.root.height/2))
+	if err != nil {
+		cmn.PanicSanity(cmn.Fmt("GetChunkHashes: %s", err))
+	}
+	proofs := make([]*InnerKeyProof, len(keys))
+
+	for i, k := range keys {
+		proof, err := tree.getInnerWithProof(k)
+		if err != nil {
+			cmn.PanicSanity(cmn.Fmt("Error getting inner key proof: %s", err))
+		}
+		proofs[i] = proof
+	}
+	return hashes, proofs, depth
+}
+
+// getNodes returns an array of nodes at the given depth.
+func getNodes(tree *Tree, depth uint) []*Node {
+	nodes := make([]*Node, 0, 1<<depth)
+	tree.root.traverseDepth(tree, depth, func(node *Node) {
+		nodes = append(nodes, node)
+	})
+	return nodes
+}
+
+// call cb for every node exactly depth levels below it
+// depth first search to return in tree ordering.
+func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
+	// base case
+	if depth == 0 {
+		cb(node)
+		return
+	}
+	if node.isLeaf() {
+		return
+	}
+
+	// otherwise, descend one more level
+	node.getLeftNode(t).traverseDepth(t, depth-1, cb)
+	node.getRightNode(t).traverseDepth(t, depth-1, cb)
+}
+
+// position to key can calculate the appropriate sort order
+// for the count-th node at a given depth, assuming a full
+// tree above this height.
+func positionToKey(depth, count uint) (key uint64) {
+	for d := depth; d > 0; d-- {
+		// lowest digit of count * 2^(d-1)
+		key += uint64((count & 1) << (d - 1))
+		count = count >> 1
+	}
+	return
+}
+
+// GetChunk finds the count-th subtree at depth and
+// generates a Chunk for that data.
+func GetChunk(tree *Tree, depth, count uint) Chunk {
+	node := getNodes(tree, depth)[count]
+	prefix := positionToKey(depth, count)
+	return getChunk(tree, node, prefix, depth)
+}
+
+// getChunk takes a node and serializes all nodes below it
+//
+// As it is part of a larger tree, prefix defines the path
+// up to this point, and depth the current depth
+// (which defines where we add to the prefix)
+//
+// TODO: make this more efficient, *Chunk as arg???
+func getChunk(t *Tree, node *Node, prefix uint64, depth uint) Chunk {
+	if node.isLeaf() {
+		return Chunk{NewOrderedNode(node, prefix)}
+	}
+	res := make(Chunk, 0, node.size)
+	if node.leftNode != nil {
+		left := getChunk(t, node.getLeftNode(t), prefix, depth+1)
+		res = append(res, left...)
+	}
+	if node.rightNode != nil {
+		offset := prefix + 1<<depth
+		right := getChunk(t, node.getRightNode(t), offset, depth+1)
+		res = append(res, right...)
+	}
+	return res
+}
+
+// Sort does an inline quicksort.
+func (c Chunk) Sort() {
+	sort.Slice(c, func(i, j int) bool {
+		return c[i].SortOrder < c[j].SortOrder
+	})
+}
+
+// MergeChunks does a merge sort of the two Chunks,
+// assuming they were already in sorted order.
+func MergeChunks(left, right Chunk) Chunk {
+	size, i, j := len(left)+len(right), 0, 0
+	slice := make([]OrderedNodeData, size)
+
+	for k := 0; k < size; k++ {
+		if i > len(left)-1 && j <= len(right)-1 {
+			slice[k] = right[j]
+			j++
+		} else if j > len(right)-1 && i <= len(left)-1 {
+			slice[k] = left[i]
+			i++
+		} else if left[i].SortOrder < right[j].SortOrder {
+			slice[k] = left[i]
+			i++
+		} else {
+			slice[k] = right[j]
+			j++
+		}
+	}
+	return Chunk(slice)
+}
+
+// CalculateRoot creates a temporary in-memory
+// iavl tree to calculate the root hash of inserting
+// all the nodes.
+func (c Chunk) CalculateRoot() []byte {
+	test := NewTree(nil, 2*len(c))
+	c.PopulateTree(test)
+	return test.Hash()
+}
+
+// PopulateTree adds all the chunks in order to the given tree.
+func (c Chunk) PopulateTree(empty *Tree) {
+	for _, data := range c {
+		empty.Set(data.Key, data.Value)
+	}
+}

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -1,0 +1,103 @@
+package iavl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tmlibs/db"
+)
+
+func TestSimpleChunk(t *testing.T) {
+	require := require.New(t)
+
+	// get the chunk info we use
+	tree := makeRandomTree(TreeSize)
+	hashes, _, _, err := getChunkHashes(tree, 0)
+	require.NoError(err)
+	require.Equal(1, len(hashes))
+	hash := hashes[0]
+	require.Equal(tree.Hash(), hash)
+
+	// get tree as one chunk
+	chunk := GetChunk(tree, 0, 0)
+	require.NotEmpty(chunk)
+	require.Equal(tree.Size(), len(chunk))
+
+	// sort chunk and check integrity
+	chunk.Sort()
+	check := chunk.CalculateRoot()
+	require.Equal(hash, check)
+
+	// Trying to get chunks with a depth that exceeds the maximum allowed
+	// returns an error.
+	_, _, _, err = getChunkHashes(tree, 99)
+	require.Error(err)
+}
+
+func TestMultipleChunks(t *testing.T) {
+	require := require.New(t)
+
+	cases := []struct {
+		depth uint
+	}{
+		{0},
+		{1},
+		{4},
+		{7},
+	}
+
+	// get the chunk info we use
+	tree := makeRandomTree(TreeSize)
+
+	for _, tc := range cases {
+		hashes, _, depth, err := getChunkHashes(tree, tc.depth)
+		require.NoError(err)
+		numChunks := len(hashes)
+		require.Equal(1<<depth, numChunks, "%d", tc.depth)
+
+		var accum Chunk
+		for i := 0; i < numChunks; i++ {
+			// get tree as one chunk
+			chunk := GetChunk(tree, depth, uint(i))
+			require.NotEmpty(chunk, "%d/%d", depth, i)
+
+			// sort chunk and check integrity
+			chunk.Sort()
+			check := chunk.CalculateRoot()
+			require.Equal(hashes[i], check, "%d/%d", depth, i)
+
+			// add this chunk to our accum
+			accum = MergeChunks(accum, chunk)
+		}
+
+		require.Equal(tree.Size(), len(accum))
+		final := accum.CalculateRoot()
+		require.Equal(tree.Hash(), final, "%d", tc.depth)
+	}
+}
+
+func TestChunkProofs(t *testing.T) {
+	require := require.New(t)
+	tree := makeAlphabetTree()
+
+	hashes, proofs, _ := GetChunkHashesWithProofs(tree)
+	require.NotEmpty(hashes)
+	require.Equal(len(hashes), len(proofs))
+
+	for i, hash := range hashes {
+		err := proofs[i].Verify(hash, nil, tree.Hash())
+		require.NoError(err)
+	}
+}
+
+func makeAlphabetTree() *Tree {
+	t := NewTree(db.NewMemDB(), 26)
+	alpha := []byte("abcdefghijklmnopqrstuvwxyz")
+
+	for _, a := range alpha {
+		t.Set([]byte{a}, []byte{a})
+	}
+	t.Hash()
+
+	return t
+}

--- a/node.go
+++ b/node.go
@@ -178,20 +178,6 @@ func (node *Node) getByIndex(t *Tree, index int64) (key []byte, value []byte) {
 	}
 }
 
-func (node *Node) getFirstChild(t *Tree, key []byte) *Node {
-	cmp := bytes.Compare(key, node.key)
-
-	if cmp == 0 {
-		return node
-	} else if node.isLeaf() {
-		return nil
-	} else if cmp > 0 {
-		return node.getRightNode(t).getFirstChild(t, key)
-	} else {
-		return node.getLeftNode(t).getFirstChild(t, key)
-	}
-}
-
 // Computes the hash of the node without computing its descendants. Must be
 // called on nodes which have descendant node hashes already computed.
 func (node *Node) _hash() []byte {
@@ -526,23 +512,6 @@ func (node *Node) traverse(t *Tree, ascending bool, cb func(*Node) bool) bool {
 
 func (node *Node) traverseWithDepth(t *Tree, ascending bool, cb func(*Node, uint8) bool) bool {
 	return node.traverseInRange(t, nil, nil, ascending, false, 0, cb)
-}
-
-// call cb for every node exactly depth levels below it
-// depth first search to return in tree ordering.
-func (node *Node) traverseDepth(t *Tree, depth uint, cb func(*Node)) {
-	// base case
-	if depth == 0 {
-		cb(node)
-		return
-	}
-	if node.isLeaf() {
-		return
-	}
-
-	// otherwise, descend one more level
-	node.getLeftNode(t).traverseDepth(t, depth-1, cb)
-	node.getRightNode(t).traverseDepth(t, depth-1, cb)
 }
 
 func (node *Node) traverseInRange(t *Tree, start, end []byte, ascending bool, inclusive bool, depth uint8, cb func(*Node, uint8) bool) bool {

--- a/proof.go
+++ b/proof.go
@@ -205,6 +205,27 @@ func (t *Tree) getWithProof(key []byte) (value []byte, proof *KeyExistsProof, er
 	return node.value, proof, nil
 }
 
+func (t *Tree) getInnerWithProof(key []byte) (proof *InnerKeyProof, err error) {
+	if t.root == nil {
+		return nil, errors.WithStack(ErrNilRoot)
+	}
+	t.root.hashWithCount() // Ensure that all hashes are calculated.
+
+	path, node, err := t.root.pathToInnerKey(t, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not construct path to key")
+	}
+
+	proof = &InnerKeyProof{
+		&KeyExistsProof{
+			RootHash:  t.root.hash,
+			PathToKey: path,
+			Version:   node.version,
+		},
+	}
+	return proof, nil
+}
+
 func (t *Tree) keyAbsentProof(key []byte) (*KeyAbsentProof, error) {
 	if t.root == nil {
 		return nil, errors.WithStack(ErrNilRoot)

--- a/proof_key.go
+++ b/proof_key.go
@@ -127,3 +127,28 @@ func ReadKeyProof(data []byte) (KeyProof, error) {
 	}
 	return nil, errors.New("unrecognized proof")
 }
+
+///////////////////////////////////////////////////////////////////////////////
+
+// InnerKeyProof represents a proof of existence of an inner node key.
+type InnerKeyProof struct {
+	*KeyExistsProof
+}
+
+// Verify verifies the proof is valid and returns an error if it isn't.
+func (proof *InnerKeyProof) Verify(hash []byte, value []byte, root []byte) error {
+	if !bytes.Equal(proof.RootHash, root) {
+		return errors.WithStack(ErrInvalidRoot)
+	}
+	if hash == nil || value != nil {
+		return errors.WithStack(ErrInvalidInputs)
+	}
+	return proof.PathToKey.verify(hash, root)
+}
+
+// ReadKeyInnerProof will deserialize a InnerKeyProof from bytes.
+func ReadInnerKeyProof(data []byte) (*InnerKeyProof, error) {
+	proof := new(InnerKeyProof)
+	err := wire.ReadBinaryBytes(data, &proof)
+	return proof, err
+}

--- a/serialize.go
+++ b/serialize.go
@@ -2,61 +2,32 @@ package iavl
 
 // NodeData groups together a key, value and depth.
 type NodeData struct {
-	Key          []byte
-	Value        []byte
-	Depth        uint8
-	Version      int64
-	InnerVersion int64
+	Key   []byte
+	Value []byte
+	Depth uint8
 }
 
-// Serializer is anything that can serialize and restore a *Tree.
-type Serializer interface {
-	Serialize(*Tree, *Node) []NodeData
-	Restore(*Tree, []NodeData)
+// SerializeFunc is any implementation that can serialize
+// an iavl Node and its descendants.
+type SerializeFunc func(*Tree, *Node) []NodeData
+
+// RestoreFunc is an implementation that can restore an iavl tree from
+// NodeData.
+type RestoreFunc func(*Tree, []NodeData)
+
+// Restore will take an (empty) tree restore it
+// from the keys returned from a SerializeFunc.
+func Restore(empty *Tree, kvs []NodeData) {
+	for _, kv := range kvs {
+		empty.Set(kv.Key, kv.Value)
+	}
+	empty.Hash()
 }
 
-// NewSerializer returns a new serializer using the default algorithm.
-func NewSerializer() Serializer {
-	return &inOrderSerializer{}
-}
-
-// inOrderSerializer serializes a tree in sort order and restores trees
-// bottom-up using depth information.
-type inOrderSerializer struct{}
-
-var _ Serializer = &inOrderSerializer{}
-
-// To serialize in-order, we have to store the depth of each leaf node, as well
-// as all inner-node versions. We store inner-node versions in the leaves, using
-// the same algorith as keys: the version of an inner-node is stored in the leftmost
-// leaf of the right child of that inner-node. Therefore, just like with keys,
-// all but the very first leaf (NodeData) stores inner node versions.
-func (s *inOrderSerializer) Serialize(t *Tree, root *Node) []NodeData {
-	res := make([]NodeData, 0, root.size)
-	root.traverseWithDepth(t, true, func(node *Node, depth uint8) bool {
-		if node.isLeaf() {
-			// The inner parent with the same key as this leaf node will store
-			// its version in this leaf.
-			innerVersion := root.getFirstChild(t, node.key).version
-			kv := NodeData{
-				Key:          node.key,
-				Value:        node.value,
-				Version:      node.version,
-				InnerVersion: innerVersion,
-				Depth:        depth,
-			}
-			res = append(res, kv)
-		}
-		return false
-	})
-	return res
-}
-
-func (s *inOrderSerializer) Restore(empty *Tree, kvs []NodeData) {
+func RestoreUsingDepth(empty *Tree, kvs []NodeData) {
 	// Create an array of arrays of nodes. We're going to store each depth in
 	// here, forming a kind of pyramid.
 	depths := [][]*Node{}
-	innerVersions := map[string]int64{}
 
 	// Go through all the leaf nodes, grouping them in pairs and creating their
 	// parents recursively.
@@ -64,7 +35,7 @@ func (s *inOrderSerializer) Restore(empty *Tree, kvs []NodeData) {
 		var (
 			// Left and right nodes.
 			l     *Node = nil
-			r     *Node = NewNode(kv.Key, kv.Value, kv.Version)
+			r     *Node = NewNode(kv.Key, kv.Value, 1)
 			depth uint8 = kv.Depth
 		)
 		// Create depths as needed.
@@ -72,11 +43,6 @@ func (s *inOrderSerializer) Restore(empty *Tree, kvs []NodeData) {
 			depths = append(depths, []*Node{})
 		}
 		depths[depth] = append(depths[depth], r) // Add the leaf node to this depth.
-
-		// Since leaf nodes only store their own versions, we have to store the
-		// inner version separately, so that as we build the inner parents, we
-		// can quickly retrieve their versions.
-		innerVersions[string(kv.Key)] = kv.InnerVersion
 
 		// If the nodes at this level are uneven after adding a node to it, it
 		// means we have to wait for another node to be appended before we have
@@ -87,16 +53,13 @@ func (s *inOrderSerializer) Restore(empty *Tree, kvs []NodeData) {
 			l = nodes[len(nodes)-1-1]
 			r = nodes[len(nodes)-1]
 
-			leftmostKey := leftmost(nil, r).Key
-			version := innerVersions[string(leftmostKey)]
-
 			depths[d-1] = append(depths[d-1], &Node{
-				key:       leftmostKey,
+				key:       leftmost(r).Key,
 				height:    maxInt8(l.height, r.height) + 1,
 				size:      l.size + r.size,
 				leftNode:  l,
 				rightNode: r,
-				version:   version,
+				version:   1,
 			})
 		}
 	}
@@ -104,19 +67,23 @@ func (s *inOrderSerializer) Restore(empty *Tree, kvs []NodeData) {
 	empty.Hash()
 }
 
-// breadthFirstSerializer can serialize a tree in a breadth-first manner.
-type breadthFirstSerializer struct{}
-
-var _ Serializer = &breadthFirstSerializer{}
-
-func (s *breadthFirstSerializer) Restore(empty *Tree, kvs []NodeData) {
-	for _, kv := range kvs {
-		empty.Set(kv.Key, kv.Value)
-	}
-	empty.Hash()
+// InOrderSerialize returns all key-values in the
+// key order (as stored). May be nice to read, but
+// when recovering, it will create a different.
+func InOrderSerialize(t *Tree, root *Node) []NodeData {
+	res := make([]NodeData, 0, root.size)
+	root.traverseWithDepth(t, true, func(node *Node, depth uint8) bool {
+		if node.height == 0 {
+			kv := NodeData{Key: node.key, Value: node.value, Depth: depth}
+			res = append(res, kv)
+		}
+		return false
+	})
+	return res
 }
 
-func (s *breadthFirstSerializer) Serialize(t *Tree, root *Node) []NodeData {
+// StableSerializeBFS serializes the tree in a breadth-first manner.
+func StableSerializeBFS(t *Tree, root *Node) []NodeData {
 	if root == nil {
 		return nil
 	}
@@ -148,9 +115,70 @@ func (s *breadthFirstSerializer) Serialize(t *Tree, root *Node) []NodeData {
 
 	nds := make([]NodeData, size)
 	for i, k := range keys {
-		nds[i] = NodeData{k, visited[string(k)], 0, 1, 1}
+		nds[i] = NodeData{k, visited[string(k)], 0}
 	}
 	return nds
+}
+
+// StableSerializeFrey exports the key value pairs of the tree
+// in an order, such that when Restored from those keys, the
+// new tree would have the same structure (and thus same
+// shape) as the original tree.
+//
+// the algorithm is basically this: take the leftmost node
+// of the left half and the leftmost node of the righthalf.
+// Then go down a level...
+// each time adding leftmost node of the right side.
+// (bredth first search)
+//
+// Imagine 8 nodes in a balanced tree, split in half each time
+// 1
+// 1, 5
+// 1, 5, 3, 7
+// 1, 5, 3, 7, 2, 4, 6, 8
+func StableSerializeFrey(t *Tree, top *Node) []NodeData {
+	if top == nil {
+		return nil
+	}
+	size := top.size
+
+	// store all pending nodes for depth-first search
+	queue := make([]*Node, 0, size)
+	queue = append(queue, top)
+
+	// to store all results - started with
+	res := make([]NodeData, 0, size)
+	left := leftmost(top)
+	if left != nil {
+		res = append(res, *left)
+	}
+
+	var n *Node
+	for len(queue) > 0 {
+		// pop
+		n, queue = queue[0], queue[1:]
+
+		// l := n.getLeftNode(tree)
+		l := n.leftNode
+		if isInner(l) {
+			queue = append(queue, l)
+		}
+
+		// r := n.getRightNode(tree)
+		r := n.rightNode
+		if isInner(r) {
+			queue = append(queue, r)
+			left = leftmost(r)
+			if left != nil {
+				res = append(res, *left)
+			}
+		} else if isLeaf(r) {
+			kv := NodeData{Key: r.key, Value: r.value}
+			res = append(res, kv)
+		}
+	}
+
+	return res
 }
 
 func isInner(n *Node) bool {
@@ -161,9 +189,9 @@ func isLeaf(n *Node) bool {
 	return n != nil && n.isLeaf()
 }
 
-func leftmost(t *Tree, node *Node) *NodeData {
+func leftmost(node *Node) *NodeData {
 	for isInner(node) {
-		node = node.getLeftNode(t)
+		node = node.leftNode
 	}
 	if node == nil {
 		return nil


### PR DESCRIPTION
Reverts tendermint/iavl#24

* The implementation is broken, since inner node versions are not always equal to the left-most leaf's version.
* Need to remove breadth-first serialization logic.