### PR TITLE
Switch from go-wire to go-amino

### DIFF
--- a/amino.go
+++ b/amino.go
@@ -1,0 +1,5 @@
+package iavl
+
+import "github.com/tendermint/go-amino"
+
+var cdc = amino.NewCodec()

--- a/amino.go
+++ b/amino.go
@@ -1,6 +1,5 @@
 package iavl
 
-// TODO(ismail): remove alias when we switch to more recent version of go-amino
-import amino "github.com/tendermint/go-amino"
+import "github.com/tendermint/go-amino"
 
 var cdc = amino.NewCodec()

--- a/amino.go
+++ b/amino.go
@@ -1,5 +1,6 @@
 package iavl
 
-import "github.com/tendermint/go-amino"
+// TODO(ismail): remove alias when we switch to more recent version of go-amino
+import amino "github.com/tendermint/go-amino"
 
 var cdc = amino.NewCodec()

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: ae99beaaf9e18324c79e4144a30e73d1a009e005dadfd6d9a4739e674ded385c
-updated: 2018-02-02T23:51:14.356463651-05:00
+hash: 34e81736343fa6e671443d60ededb5864a3c87ed185952b93a1e97065031e825
+updated: 2018-05-04T11:17:57.011868543+01:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/go-kit/kit
-  version: 4dc7be5d2d12881735283bcab7352178e190fc71
+  version: ca4112baa34cb55091301bdc13b1420a122b1b9e
   subpackages:
   - log
   - log/level
@@ -44,10 +44,10 @@ imports:
   - leveldb/storage
   - leveldb/table
   - leveldb/util
-- name: github.com/tendermint/go-wire
-  version: dec83f641903b22f039da3974607859715d0377e
+- name: github.com/tendermint/go-amino
+  version: ed62928576cfcaf887209dc96142cd79cdfff389
 - name: github.com/tendermint/tmlibs
-  version: 1d7fc78ea171587e9e63da566d3da1b127bfd14c
+  version: cc5f287c4798ffe88c04d02df219ecb6932080fd
   subpackages:
   - common
   - db
@@ -57,6 +57,7 @@ imports:
   version: edd5e9b0879d13ee6970a50153d85b8fec9f7686
   subpackages:
   - ripemd160
+  - sha3
 testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d

--- a/glide.lock
+++ b/glide.lock
@@ -45,7 +45,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/go-amino
-  version: ed62928576cfcaf887209dc96142cd79cdfff389
+  version: 5d7845f24b843c914cf571dad2ca13c91cf70f0d
 - name: github.com/tendermint/tmlibs
   version: cc5f287c4798ffe88c04d02df219ecb6932080fd
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 34e81736343fa6e671443d60ededb5864a3c87ed185952b93a1e97065031e825
-updated: 2018-05-04T11:17:57.011868543+01:00
+updated: 2018-05-05T00:48:30.21520063+01:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 346938d642f2ec3594ed81d874461961cd0faa76
@@ -45,7 +45,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/go-amino
-  version: 5d7845f24b843c914cf571dad2ca13c91cf70f0d
+  version: ed62928576cfcaf887209dc96142cd79cdfff389
 - name: github.com/tendermint/tmlibs
   version: cc5f287c4798ffe88c04d02df219ecb6932080fd
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/tendermint/iavl
 import:
 - package: github.com/pkg/errors
   version: ^0.8.0
-- package: github.com/tendermint/go-wire
+- package: github.com/tendermint/go-amino
   version: develop
 - package: github.com/tendermint/tmlibs
   version: develop

--- a/node.go
+++ b/node.go
@@ -9,9 +9,7 @@ import (
 	"io"
 
 	"golang.org/x/crypto/ripemd160"
-	// TODO(ismail): remove alias as soon as we use a more recent version of go-amino
-	// where package wire is renamed to amino
-	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/go-amino"
 )
 
 // Node represents a node in a Tree.
@@ -47,11 +45,14 @@ func NewNode(key []byte, value []byte, version int64) *Node {
 func MakeNode(buf []byte) (node *Node, err error) {
 	node = &Node{}
 
+	// Keeps track of bytes read.
+	n := 0
+
 	// Read node header.
-
-	node.height = int8(buf[0])
-
-	n := 1 // Keeps track of bytes read.
+	node.height, n, err = amino.DecodeInt8(buf)
+	if err != nil {
+		return nil, err
+	}
 	buf = buf[n:]
 
 	node.size, n, err = amino.DecodeInt64(buf)

--- a/node.go
+++ b/node.go
@@ -9,8 +9,9 @@ import (
 	"io"
 
 	"golang.org/x/crypto/ripemd160"
-
-	"github.com/tendermint/go-amino"
+	// TODO(ismail): remove alias as soon as we use a more recent version of go-amino
+	// where package wire is renamed to amino
+	amino "github.com/tendermint/go-amino"
 )
 
 // Node represents a node in a Tree.

--- a/node.go
+++ b/node.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/crypto/ripemd160"
 
-	"github.com/tendermint/go-wire"
+	"github.com/tendermint/go-amino"
 )
 
 // Node represents a node in a Tree.
@@ -53,19 +53,19 @@ func MakeNode(buf []byte) (node *Node, err error) {
 	n := 1 // Keeps track of bytes read.
 	buf = buf[n:]
 
-	node.size, n, err = wire.DecodeInt64(buf)
+	node.size, n, err = amino.DecodeInt64(buf)
 	if err != nil {
 		return nil, err
 	}
 	buf = buf[n:]
 
-	node.version, n, err = wire.DecodeInt64(buf)
+	node.version, n, err = amino.DecodeInt64(buf)
 	if err != nil {
 		return nil, err
 	}
 	buf = buf[n:]
 
-	node.key, n, err = wire.DecodeByteSlice(buf)
+	node.key, n, err = amino.DecodeByteSlice(buf)
 	if err != nil {
 		return nil, err
 	}
@@ -74,18 +74,18 @@ func MakeNode(buf []byte) (node *Node, err error) {
 	// Read node body.
 
 	if node.isLeaf() {
-		node.value, _, err = wire.DecodeByteSlice(buf)
+		node.value, _, err = amino.DecodeByteSlice(buf)
 		if err != nil {
 			return nil, err
 		}
 	} else { // Read children.
-		leftHash, n, err := wire.DecodeByteSlice(buf)
+		leftHash, n, err := amino.DecodeByteSlice(buf)
 		if err != nil {
 			return nil, err
 		}
 		buf = buf[n:]
 
-		rightHash, _, err := wire.DecodeByteSlice(buf)
+		rightHash, _, err := amino.DecodeByteSlice(buf)
 		if err != nil {
 			return nil, err
 		}
@@ -224,32 +224,32 @@ func (node *Node) hashWithCount() ([]byte, int64) {
 // Writes the node's hash to the given io.Writer. This function expects
 // child hashes to be already set.
 func (node *Node) writeHashBytes(w io.Writer) (err error) {
-	err = wire.EncodeInt8(w, node.height)
+	err = amino.EncodeInt8(w, node.height)
 	if err == nil {
-		err = wire.EncodeInt64(w, node.size)
+		err = amino.EncodeInt64(w, node.size)
 	}
 	if err == nil {
-		err = wire.EncodeInt64(w, node.version)
+		err = amino.EncodeInt64(w, node.version)
 	}
 
 	// Key is not written for inner nodes, unlike writeBytes.
 
 	if node.isLeaf() {
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.key)
+			err = amino.EncodeByteSlice(w, node.key)
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.value)
+			err = amino.EncodeByteSlice(w, node.value)
 		}
 	} else {
 		if node.leftHash == nil || node.rightHash == nil {
 			panic("Found an empty child hash")
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.leftHash)
+			err = amino.EncodeByteSlice(w, node.leftHash)
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.rightHash)
+			err = amino.EncodeByteSlice(w, node.rightHash)
 		}
 	}
 	return
@@ -275,36 +275,36 @@ func (node *Node) writeHashBytesRecursively(w io.Writer) (hashCount int64, err e
 
 // Writes the node as a serialized byte slice to the supplied io.Writer.
 func (node *Node) writeBytes(w io.Writer) (err error) {
-	err = wire.EncodeInt8(w, node.height)
+	err = amino.EncodeInt8(w, node.height)
 	if err == nil {
-		err = wire.EncodeInt64(w, node.size)
+		err = amino.EncodeInt64(w, node.size)
 	}
 	if err == nil {
-		err = wire.EncodeInt64(w, node.version)
+		err = amino.EncodeInt64(w, node.version)
 	}
 
 	// Unlike writeHashBytes, key is written for inner nodes.
 	if err == nil {
-		err = wire.EncodeByteSlice(w, node.key)
+		err = amino.EncodeByteSlice(w, node.key)
 	}
 
 	if node.isLeaf() {
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.value)
+			err = amino.EncodeByteSlice(w, node.value)
 		}
 	} else {
 		if node.leftHash == nil {
 			panic("node.leftHash was nil in writeBytes")
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.leftHash)
+			err = amino.EncodeByteSlice(w, node.leftHash)
 		}
 
 		if node.rightHash == nil {
 			panic("node.rightHash was nil in writeBytes")
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(w, node.rightHash)
+			err = amino.EncodeByteSlice(w, node.rightHash)
 		}
 	}
 	return

--- a/nodedb.go
+++ b/nodedb.go
@@ -431,7 +431,7 @@ func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node)) {
 	ndb.traversePrefix([]byte(nodePrefix), func(key, value []byte) {
 		node, err := MakeNode(value)
 		if err != nil {
-			panic("Couldn't decode node from database")
+			panic(fmt.Sprintf("Couldn't decode node from database: %v", err))
 		}
 		fmt.Sscanf(string(key), nodeKeyFmt, &node.hash)
 		nodes = append(nodes, node)

--- a/proof.go
+++ b/proof.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ripemd160"
 
-	"github.com/tendermint/go-wire"
+	"github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 
@@ -41,27 +41,27 @@ func (branch proofInnerNode) Hash(childHash []byte) []byte {
 	hasher := ripemd160.New()
 	buf := new(bytes.Buffer)
 
-	err := wire.EncodeInt8(buf, branch.Height)
+	err := amino.EncodeInt8(buf, branch.Height)
 	if err == nil {
-		err = wire.EncodeInt64(buf, branch.Size)
+		err = amino.EncodeInt64(buf, branch.Size)
 	}
 	if err == nil {
-		err = wire.EncodeInt64(buf, branch.Version)
+		err = amino.EncodeInt64(buf, branch.Version)
 	}
 
 	if len(branch.Left) == 0 {
 		if err == nil {
-			err = wire.EncodeByteSlice(buf, childHash)
+			err = amino.EncodeByteSlice(buf, childHash)
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(buf, branch.Right)
+			err = amino.EncodeByteSlice(buf, branch.Right)
 		}
 	} else {
 		if err == nil {
-			err = wire.EncodeByteSlice(buf, branch.Left)
+			err = amino.EncodeByteSlice(buf, branch.Left)
 		}
 		if err == nil {
-			err = wire.EncodeByteSlice(buf, childHash)
+			err = amino.EncodeByteSlice(buf, childHash)
 		}
 	}
 	if err != nil {
@@ -82,18 +82,18 @@ func (leaf proofLeafNode) Hash() []byte {
 	hasher := ripemd160.New()
 	buf := new(bytes.Buffer)
 
-	err := wire.EncodeInt8(buf, 0)
+	err := amino.EncodeInt8(buf, 0)
 	if err == nil {
-		err = wire.EncodeInt64(buf, 1)
+		err = amino.EncodeInt64(buf, 1)
 	}
 	if err == nil {
-		err = wire.EncodeInt64(buf, leaf.Version)
+		err = amino.EncodeInt64(buf, leaf.Version)
 	}
 	if err == nil {
-		err = wire.EncodeByteSlice(buf, leaf.KeyBytes)
+		err = amino.EncodeByteSlice(buf, leaf.KeyBytes)
 	}
 	if err == nil {
-		err = wire.EncodeByteSlice(buf, leaf.ValueBytes)
+		err = amino.EncodeByteSlice(buf, leaf.ValueBytes)
 	}
 	if err != nil {
 		panic(fmt.Sprintf("Failed to hash proofLeafNode: %v", err))

--- a/proof.go
+++ b/proof.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ripemd160"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 

--- a/proof.go
+++ b/proof.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ripemd160"
 
-	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/go-amino"
 	cmn "github.com/tendermint/tmlibs/common"
 )
 

--- a/proof_key.go
+++ b/proof_key.go
@@ -50,7 +50,7 @@ func (proof *KeyExistsProof) Verify(key []byte, value []byte, root []byte) error
 	return proof.PathToKey.verify(proofLeafNode{key, value, proof.Version}.Hash(), root)
 }
 
-// Bytes returns a go-wire binary serialization
+// Bytes returns a go-amino binary serialization
 func (proof *KeyExistsProof) Bytes() []byte {
 	bz, err := cdc.MarshalBinary(proof)
 	if err != nil {

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tendermint/tmlibs/db"
 	. "github.com/tendermint/tmlibs/test"
 
-	"github.com/tendermint/go-amino"
+	amino "github.com/tendermint/go-amino"
 )
 
 func dummyPathToKey(t *Tree, key []byte) *PathToKey {

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -3,17 +3,19 @@ package iavl
 import (
 	"bytes"
 	"fmt"
+	"runtime"
+	"testing"
+
 	mrand "math/rand"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/go-wire"
+
 	. "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/db"
 	. "github.com/tendermint/tmlibs/test"
 
-	"runtime"
-	"testing"
+	"github.com/tendermint/go-amino"
 )
 
 func dummyPathToKey(t *Tree, key []byte) *PathToKey {
@@ -34,12 +36,12 @@ func randstr(length int) string {
 
 func i2b(i int) []byte {
 	buf := new(bytes.Buffer)
-	wire.EncodeInt32(buf, int32(i))
+	amino.EncodeInt32(buf, int32(i))
 	return buf.Bytes()
 }
 
 func b2i(bz []byte) int {
-	i, _, _ := wire.DecodeInt32(bz)
+	i, _, _ := amino.DecodeInt32(bz)
 	return int(i)
 }
 

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tendermint/tmlibs/db"
 	. "github.com/tendermint/tmlibs/test"
 
-	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/go-amino"
 )
 
 func dummyPathToKey(t *Tree, key []byte) *PathToKey {

--- a/wire.go
+++ b/wire.go
@@ -1,7 +1,0 @@
-package iavl
-
-import (
-	"github.com/tendermint/go-wire"
-)
-
-var cdc = wire.NewCodec()


### PR DESCRIPTION
Use latest amino instead of go-wire (see #51)

WIP / Notes: After switching to amino e.g. `TestVersionedRandomTreeSmallKeys`
currently fails/panics (at least most of the times) with: 

panic: Error reading Node. bytes: [...] error: insufficient bytes decoding []byte of length [...]

`TestTreeKeyRangeProof` fails with "invalid proof"