### PR TITLE
IterateRange bugfix

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -311,7 +311,6 @@ func TestIterateRange(t *testing.T) {
 			t.Error("should have not been updated")
 		}
 	}
-
 	// test traversing the whole node works... in order
 	viewed := []string{}
 	tree.Iterate(func(key []byte, value []byte) bool {
@@ -330,6 +329,10 @@ func TestIterateRange(t *testing.T) {
 	trav := traverser{}
 	tree.IterateRange([]byte("foo"), []byte("goo"), true, trav.view)
 	expectTraverse(t, trav, "foo", "food", 5)
+
+	trav = traverser{}
+	tree.IterateRange([]byte("aaa"), []byte("abb"), true, trav.view)
+	expectTraverse(t, trav, "", "", 0)
 
 	trav = traverser{}
 	tree.IterateRange(nil, []byte("flap"), true, trav.view)

--- a/node.go
+++ b/node.go
@@ -585,7 +585,7 @@ func (node *Node) traverseInRange(t *Tree, start, end []byte, ascending bool, in
 
 	// Run callback per inner/leaf node.
 	stop := false
-	if !node.isLeaf() || startOrAfter {
+	if !node.isLeaf() || (startOrAfter && beforeEnd) {
 		stop = cb(node, depth)
 		if stop {
 			return stop


### PR DESCRIPTION
With current code, if you call Tree.IterateRange with a range to the left of the left most leaf node, the function will return that first leaf node anyway. Fix checks start and end before returning leaf nodes from node.traverseInRange.

See also: https://github.com/cosmos/cosmos-sdk/pull/931#issuecomment-400884242