### PR TITLE
Fix linting error on the sdk

### DIFF
--- a/proof_range.go
+++ b/proof_range.go
@@ -289,7 +289,7 @@ func (t *Tree) getRangeProof(keyStart, keyEnd []byte, limit int) (proof *RangePr
 
 	// Traverse starting from afterLeft, until keyEnd or the next leaf
 	// after keyEnd.
-	// nolint: unconvert
+	// nolint
 	var innersq = []PathToLeaf(nil)
 	var inners = PathToLeaf(nil)
 	var lastDepth uint8 = 0


### PR DESCRIPTION
For an unknown reason, this line is causing a linting error in the sdk. (Even though we have it set to ignore the vendor directories, and it succesfully ignores all other linting errors in other vendor directories)