### PR TITLE
0.9.1 -- compute hash from rangeproof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.1 (July 1, 2018)
+
+IMPROVEMENTS
+
+- RangeProof.ComputeRootHash() to compute root rather than provide as in Verify(hash)
+
 ## 0.9.0 (July 1, 2018)
 
 BREAKING CHANGES

--- a/proof_path.go
+++ b/proof_path.go
@@ -28,8 +28,19 @@ func (pwl pathWithLeaf) StringIndented(indent string) string {
 		indent)
 }
 
+// `verify` checks that the leaf node's hash + the inner nodes merkle-izes to
+// the given root. If it returns an error, it means the leafHash or the
+// PathToLeaf is incorrect.
 func (pwl pathWithLeaf) verify(root []byte) cmn.Error {
-	return pwl.Path.verify(pwl.Leaf.Hash(), root)
+	leafHash := pwl.Leaf.Hash()
+	return pwl.Path.verify(leafHash, root)
+}
+
+// `computeRootHash` computes the root hash with leaf node.
+// Does not verify the root hash.
+func (pwl pathWithLeaf) computeRootHash() []byte {
+	leafHash := pwl.Leaf.Hash()
+	return pwl.Path.computeRootHash(leafHash)
 }
 
 //----------------------------------------
@@ -62,9 +73,9 @@ func (pl PathToLeaf) StringIndented(indent string) string {
 		indent)
 }
 
-// verify checks that the leaf node's hash + the inner nodes merkle-izes to the
-// given root. If it returns an error, it means the leafHash or the PathToLeaf
-// is incorrect.
+// `verify` checks that the leaf node's hash + the inner nodes merkle-izes to
+// the given root. If it returns an error, it means the leafHash or the
+// PathToLeaf is incorrect.
 func (pl PathToLeaf) verify(leafHash []byte, root []byte) cmn.Error {
 	hash := leafHash
 	for i := len(pl) - 1; i >= 0; i-- {
@@ -75,6 +86,17 @@ func (pl PathToLeaf) verify(leafHash []byte, root []byte) cmn.Error {
 		return cmn.ErrorWrap(ErrInvalidProof, "")
 	}
 	return nil
+}
+
+// `computeRootHash` computes the root hash assuming some leaf hash.
+// Does not verify the root hash.
+func (pl PathToLeaf) computeRootHash(leafHash []byte) []byte {
+	hash := leafHash
+	for i := len(pl) - 1; i >= 0; i-- {
+		pin := pl[i]
+		hash = pin.Hash(hash)
+	}
+	return hash
 }
 
 func (pl PathToLeaf) isLeftmost() bool {

--- a/proof_test.go
+++ b/proof_test.go
@@ -223,10 +223,6 @@ func verifyProof(t *testing.T, proof *RangeProof, root []byte) {
 				proofBytes, badProofBytes)
 		}
 	}
-
-	// targetted changes fails...
-	proof.RootHash = test.MutateByteSlice(proof.RootHash)
-	assert.Error(t, proof.Verify(root))
 }
 
 //----------------------------------------

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package iavl
 
-const Version = "0.9.0"
+const Version = "0.9.1"


### PR DESCRIPTION
## 0.9.1 (July 1, 2018)

IMPROVEMENTS

- RangeProof.ComputeRootHash() to compute root rather than provide as in Verify(hash)

NOTE: While RangeProof.RootHash got removed, nothing was using it so we're not calling this breaking.