### PR TITLE
Fix a bug for marking verions which is greater than target version to…

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -236,9 +236,9 @@ func (tree *MutableTree) LoadVersion(targetVersion int64) (int64, error) {
 	latestVersion := int64(0)
 	var latestRoot []byte
 	for version, r := range roots {
-		tree.versions[version] = true
 		if version > latestVersion &&
 			(targetVersion == 0 || version <= targetVersion) {
+			tree.versions[version] = true
 			latestVersion = version
 			latestRoot = r
 		}


### PR DESCRIPTION
Currently, the versions in MutableTree contains all previously saved versions of the tree.
```
type MutableTree struct {
	*ImmutableTree                  // The current, working tree.
	lastSaved      *ImmutableTree   // The most recently saved tree.
	orphans        map[string]int64 // Nodes removed by changes to working tree.
	versions       map[int64]bool   // The previous, saved versions of the tree.
	ndb            *nodeDB
}
```
The LoadVersion of MutableTree  will mark all existing version to be true. Suppose this situation, current tree version is 10, but I want to load to 9. Then versions[10] will be marked true too. However, I think this is not reasonable. Suppose I want to rewrite the latest version 10 to different value, if version[10] is true, then the new value can't be written in.
```
func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
	version := tree.version + 1

	if tree.versions[version] {
		//version already exists, throw an error if attempting to overwrite
		// Same hash means idempotent.  Return success.
		existingHash := tree.ndb.getRoot(version)
		var newHash = tree.WorkingHash()
		if bytes.Equal(existingHash, newHash) {
			tree.version = version
			tree.ImmutableTree = tree.ImmutableTree.clone()
			tree.lastSaved = tree.ImmutableTree.clone()
			tree.orphans = map[string]int64{}
			return existingHash, version, nil
		}
		return nil, version, fmt.Errorf("version %d was already saved to different hash %X (existing hash %X)",
			version, newHash, existingHash)
	}

	if tree.root == nil {
        ...
```
@jlandrews 