### PR TITLE
Use 8 bytes to store int64 components of database keys 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+BREAKING CHANGES
+
+- Changed internal database key format to store int64 key components in a full 8-byte fixed width. 
+
+
+IMPROVEMENTS
+
+- Database key format avoids use of fmt.Sprintf fmt.Sscanf leading to ~10% speedup in benchmark BenchmarkTreeLoadAndDelete
+
 ## 0.10.0
 
 BREAKING CHANGES

--- a/key_format.go
+++ b/key_format.go
@@ -1,0 +1,127 @@
+package iavl
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Provides a fixed-width lexicographically sortable []byte key format
+type KeyFormat struct {
+	prefix byte
+	layout []int
+	length int
+}
+
+// Create a []byte key format based on a single byte prefix and fixed width key segments each of whose length is
+// specified by by the corresponding element of layout
+func NewKeyFormat(prefix byte, layout ...int) *KeyFormat {
+	// For prefix
+	length := 1
+	for _, l := range layout {
+		length += int(l)
+	}
+	return &KeyFormat{
+		prefix: prefix,
+		layout: layout,
+		length: length,
+	}
+}
+
+// Format the byte segments into the key format - will panic if the segment lengths to do match the layout.
+func (kf *KeyFormat) KeyBytes(segments ...[]byte) []byte {
+	key := make([]byte, kf.length)
+	key[0] = kf.prefix
+	n := 1
+	for i, s := range segments {
+		l := kf.layout[i]
+		if len(s) > l {
+			panic(fmt.Errorf("length of segment %X provided to KeyFormat.KeyBytes() is longer than the %d bytes "+
+				"required by layout for segment %d", s, l, i))
+		}
+		n += l
+		// Big endian so pad on left if not given the full width for this segment
+		copy(key[n-len(s):n], s)
+	}
+	return key[:n]
+}
+
+// Format the args passed into the key format - will panic if the arguments passed to not match the length
+// of the segment to which they correspond. When called with no arguments returns the raw prefix (useful as a start
+// element of the entire keys space when sorted lexicographically)
+func (kf *KeyFormat) Key(args ...interface{}) []byte {
+	if len(args) > len(kf.layout) {
+		panic(fmt.Errorf("KeyFormat.Key() is provided with %d args but format only has %d segments",
+			len(args), len(kf.layout)))
+	}
+	segments := make([][]byte, len(args))
+	for i, a := range args {
+		segments[i] = format(a)
+	}
+	return kf.KeyBytes(segments...)
+}
+
+// Reads out the bytes associated with each segment of the key format from key
+func (kf *KeyFormat) ScanBytes(key []byte) [][]byte {
+	segments := make([][]byte, len(kf.layout))
+	n := 1
+	for i, l := range kf.layout {
+		n += l
+		if n > len(key) {
+			return segments[:i]
+		}
+		segments[i] = key[n-l : n]
+	}
+	return segments
+}
+
+// Extracts the segments into the values pointed to by each of args. Each arg must be a pointer to int64, uint64, or
+// []byte, and the width of the args must match layout.
+func (kf *KeyFormat) Scan(key []byte, args ...interface{}) {
+	segments := kf.ScanBytes(key)
+	if len(args) > len(segments) {
+		panic(fmt.Errorf("KeyFormat.Scan() is provided with %d args but format only has %d segments in key %X",
+			len(args), len(segments), key))
+	}
+	for i, a := range args {
+		scan(a, segments[i])
+	}
+}
+
+// Return the prefix as a string
+func (kf *KeyFormat) Prefix() string {
+	return string([]byte{kf.prefix})
+}
+
+func scan(a interface{}, value []byte) {
+	switch v := a.(type) {
+	case *int64:
+		*v = int64(binary.BigEndian.Uint64(value))
+	case *uint64:
+		*v = binary.BigEndian.Uint64(value)
+	case *[]byte:
+		*v = value
+	default:
+		panic(fmt.Errorf("KeyFormat scan() does not support scanning value of type %T: %v", a, a))
+	}
+}
+
+func format(a interface{}) []byte {
+	switch v := a.(type) {
+	case uint64:
+		bs := make([]byte, 8)
+		binary.BigEndian.PutUint64(bs, v)
+		return bs
+	case uint:
+		return format(uint64(v))
+	case int64:
+		bs := make([]byte, 8)
+		binary.BigEndian.PutUint64(bs, uint64(v))
+		return bs
+	case int:
+		return format(int64(v))
+	case []byte:
+		return v
+	default:
+		panic(fmt.Errorf("KeyFormat format() does not support formatting value of type %T: %v", a, a))
+	}
+}

--- a/key_format_test.go
+++ b/key_format_test.go
@@ -1,0 +1,54 @@
+package iavl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyFormatBytes(t *testing.T) {
+	kf := NewKeyFormat(byte('e'), 8, 8, 8)
+	assert.Equal(t, []byte{'e', 0, 0, 0, 0, 0, 1, 2, 3}, kf.KeyBytes([]byte{1, 2, 3}))
+	assert.Equal(t, []byte{'e', 1, 2, 3, 4, 5, 6, 7, 8}, kf.KeyBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	assert.Equal(t, []byte{'e', 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 1, 1, 2, 2, 3, 3},
+		kf.KeyBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8}, []byte{1, 2, 3, 4, 5, 6, 7, 8}, []byte{1, 1, 2, 2, 3, 3}))
+	assert.Equal(t, []byte{'e'}, kf.KeyBytes())
+}
+
+func TestKeyFormat(t *testing.T) {
+	kf := NewKeyFormat(byte('e'), 8, 8, 8)
+	key := []byte{'e', 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 1, 144}
+	var a, b, c int64 = 100, 200, 400
+	assert.Equal(t, key, kf.Key(a, b, c))
+
+	var ao, bo, co = new(int64), new(int64), new(int64)
+	kf.Scan(key, ao, bo, co)
+	assert.Equal(t, a, *ao)
+	assert.Equal(t, b, *bo)
+	assert.Equal(t, c, *co)
+
+	bs := new([]byte)
+	kf.Scan(key, ao, bo, bs)
+	assert.Equal(t, a, *ao)
+	assert.Equal(t, b, *bo)
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 1, 144}, *bs)
+
+	assert.Equal(t, []byte{'e', 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 200}, kf.Key(a, b))
+}
+
+func TestNegativeKeys(t *testing.T) {
+	kf := NewKeyFormat(byte('e'), 8, 8)
+
+	var a, b int64 = -100, -200
+	// One's complement plus one
+	key := []byte{'e',
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, byte(0xff + a + 1),
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, byte(0xff + b + 1)}
+	assert.Equal(t, key,
+		kf.Key(a, b))
+
+	var ao, bo = new(int64), new(int64)
+	kf.Scan(key, ao, bo)
+	assert.Equal(t, a, *ao)
+	assert.Equal(t, b, *bo)
+}

--- a/key_format_test.go
+++ b/key_format_test.go
@@ -44,11 +44,27 @@ func TestNegativeKeys(t *testing.T) {
 	key := []byte{'e',
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, byte(0xff + a + 1),
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, byte(0xff + b + 1)}
-	assert.Equal(t, key,
-		kf.Key(a, b))
+	assert.Equal(t, key, kf.Key(a, b))
 
 	var ao, bo = new(int64), new(int64)
 	kf.Scan(key, ao, bo)
 	assert.Equal(t, a, *ao)
 	assert.Equal(t, b, *bo)
+}
+
+func TestOverflow(t *testing.T) {
+	kf := NewKeyFormat(byte('o'), 8, 8)
+
+	var a int64 = 1 << 62
+	var b uint64 = 1 << 63
+	key := []byte{'o',
+		0x40, 0, 0, 0, 0, 0, 0, 0,
+		0x80, 0, 0, 0, 0, 0, 0, 0,
+	}
+	assert.Equal(t, key, kf.Key(a, b))
+
+	var ao, bo = new(int64), new(int64)
+	kf.Scan(key, ao, bo)
+	assert.Equal(t, a, *ao)
+	assert.Equal(t, int64(b), *bo)
 }

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -1,0 +1,38 @@
+package iavl
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkNodeKey(b *testing.B) {
+	ndb := &nodeDB{}
+	hashes := makeHashes(b, 2432325)
+	for i := 0; i < b.N; i++ {
+		ndb.nodeKey(hashes[i])
+	}
+}
+
+func BenchmarkOrphanKey(b *testing.B) {
+	ndb := &nodeDB{}
+	hashes := makeHashes(b, 2432325)
+	for i := 0; i < b.N; i++ {
+		ndb.orphanKey(1234, 1239, hashes[i])
+	}
+}
+
+func makeHashes(b *testing.B, seed int64) [][]byte {
+	b.StopTimer()
+	rnd := rand.NewSource(seed)
+	hashes := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		hashes[i] = make([]byte, 32)
+		for b := 0; b < 32; b += 8 {
+			binary.BigEndian.PutUint64(hashes[i][b:b+8], uint64(rnd.Int63()))
+		}
+		hashes[i] = hashes[i][:20]
+	}
+	b.StartTimer()
+	return hashes
+}

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -26,12 +26,13 @@ func makeHashes(b *testing.B, seed int64) [][]byte {
 	b.StopTimer()
 	rnd := rand.NewSource(seed)
 	hashes := make([][]byte, b.N)
+	hashBytes := 8*((hashSize+7)/8)
 	for i := 0; i < b.N; i++ {
-		hashes[i] = make([]byte, 32)
-		for b := 0; b < 32; b += 8 {
+		hashes[i] = make([]byte, hashBytes)
+		for b := 0; b < hashBytes; b += 8 {
 			binary.BigEndian.PutUint64(hashes[i][b:b+8], uint64(rnd.Int63()))
 		}
-		hashes[i] = hashes[i][:20]
+		hashes[i] = hashes[i][:hashSize]
 	}
 	b.StartTimer()
 	return hashes

--- a/proof_test.go
+++ b/proof_test.go
@@ -17,7 +17,7 @@ func TestTreeGetWithProof(t *testing.T) {
 	require := require.New(t)
 	for _, ikey := range []byte{0x11, 0x32, 0x50, 0x72, 0x99} {
 		key := []byte{ikey}
-		tree.Set(key, []byte(rand.Str(8)))
+		tree.Set(key, []byte(random.Str(8)))
 	}
 	root := tree.WorkingHash()
 

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -115,8 +115,9 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 	b.StopTimer()
 
 	t := NewMutableTree(db, 100000)
+	value := []byte{}
 	for i := 0; i < 1000000; i++ {
-		t.Set(i2b(int(cmn.RandInt32())), nil)
+		t.Set(i2b(int(cmn.RandInt32())), value)
 		if i > 990000 && i%1000 == 999 {
 			t.SaveVersion()
 		}
@@ -124,14 +125,12 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 	b.ReportAllocs()
 	t.SaveVersion()
 
-	fmt.Println("ok, starting")
-
 	runtime.GC()
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		ri := i2b(int(cmn.RandInt32()))
-		t.Set(ri, nil)
+		t.Set(ri, value)
 		t.Remove(ri)
 		if i%100 == 99 {
 			t.SaveVersion()

--- a/tree_test.go
+++ b/tree_test.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -18,11 +17,11 @@ import (
 
 var testLevelDB bool
 var testFuzzIterations int
-var rand *cmn.Rand
+var random *cmn.Rand
 
 func init() {
-	rand = cmn.NewRand()
-	rand.Seed(0) // for determinism
+	random = cmn.NewRand()
+	random.Seed(0) // for determinism
 	flag.BoolVar(&testLevelDB, "test.leveldb", false, "test leveldb backend")
 	flag.IntVar(&testFuzzIterations, "test.fuzz-iterations", 100000, "number of fuzz testing iterations")
 	flag.Parse()
@@ -55,8 +54,8 @@ func TestVersionedRandomTree(t *testing.T) {
 	// Create a tree of size 1000 with 100 versions.
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
-			k := []byte(rand.Str(8))
-			v := []byte(rand.Str(8))
+			k := []byte(random.Str(8))
+			v := []byte(random.Str(8))
 			tree.Set(k, v)
 		}
 		tree.SaveVersion()
@@ -97,8 +96,8 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
 			// Keys of size one are likely to be overwritten.
-			k := []byte(rand.Str(1))
-			v := []byte(rand.Str(8))
+			k := []byte(random.Str(1))
+			v := []byte(random.Str(8))
 			tree.Set(k, v)
 			singleVersionTree.Set(k, v)
 		}
@@ -119,7 +118,7 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 
 	// Try getting random keys.
 	for i := 0; i < keysPerVersion; i++ {
-		_, val := tree.Get([]byte(rand.Str(1)))
+		_, val := tree.Get([]byte(random.Str(1)))
 		require.NotNil(val)
 		require.NotEmpty(val)
 	}
@@ -138,8 +137,8 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
 			// Keys of size one are likely to be overwritten.
-			k := []byte(rand.Str(1))
-			v := []byte(rand.Str(8))
+			k := []byte(random.Str(1))
+			v := []byte(random.Str(8))
 			tree.Set(k, v)
 			singleVersionTree.Set(k, v)
 		}
@@ -147,7 +146,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	}
 	singleVersionTree.SaveVersion()
 
-	for _, i := range rand.Perm(versions - 1) {
+	for _, i := range random.Perm(versions - 1) {
 		tree.DeleteVersion(int64(i + 1))
 	}
 
@@ -160,7 +159,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 
 	// Try getting random keys.
 	for i := 0; i < keysPerVersion; i++ {
-		_, val := tree.Get([]byte(rand.Str(1)))
+		_, val := tree.Get([]byte(random.Str(1)))
 		require.NotNil(val)
 		require.NotEmpty(val)
 	}
@@ -697,8 +696,8 @@ func TestVersionedCheckpoints(t *testing.T) {
 
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
-			k := []byte(rand.Str(1))
-			v := []byte(rand.Str(8))
+			k := []byte(random.Str(1))
+			v := []byte(random.Str(8))
 			keys[int64(i)] = append(keys[int64(i)], k)
 			tree.Set(k, v)
 		}
@@ -931,7 +930,7 @@ func TestVersionedTreeEfficiency(t *testing.T) {
 	for i := 1; i <= versions; i++ {
 		for j := 0; j < keysPerVersion; j++ {
 			// Keys of size one are likely to be overwritten.
-			tree.Set([]byte(rand.Str(1)), []byte(rand.Str(8)))
+			tree.Set([]byte(random.Str(1)), []byte(random.Str(8)))
 		}
 		sizeBefore := len(tree.ndb.nodes())
 		tree.SaveVersion()
@@ -1051,7 +1050,7 @@ func TestOrphans(t *testing.T) {
 
 	tree.ndb.traverseOrphans(func(k, v []byte) {
 		var fromVersion, toVersion int64
-		fmt.Sscanf(string(k), orphanKeyFmt, &toVersion, &fromVersion)
+		orphanKeyFormat.Scan(k, &toVersion, &fromVersion)
 		require.Equal(fromVersion, int64(1), "fromVersion should be 1")
 		require.Equal(toVersion, int64(1), "toVersion should be 1")
 	})
@@ -1182,7 +1181,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 	tree := NewMutableTree(d, 0)
 	for v := 1; v < numVersions; v++ {
 		for i := 0; i < numKeysPerVersion; i++ {
-			tree.Set([]byte(rand.Str(16)), rand.Bytes(32))
+			tree.Set([]byte(random.Str(16)), random.Bytes(32))
 		}
 		tree.SaveVersion()
 	}
@@ -1203,7 +1202,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 			// If we can load quickly into a data-structure that allows for
 			// efficient deletes, we are golden.
 			for v := 0; v < numVersions/10; v++ {
-				version := (rand.Int() % numVersions) + 1
+				version := (random.Int() % numVersions) + 1
 				tree.DeleteVersion(int64(version))
 			}
 		}


### PR DESCRIPTION
This fixes #104 by introducing `KeyFormat` that uses a fixed-width key format over the full 8 bytes provided by int64 versions in orphan, and root keys. It also relies on the fixed width format to provide more efficient code for formatting into and scanning values from keys.

As a result of this it seems to lead to a ~10% speedup in `BenchmarkTreeLoadAndDelete` by avoiding the relatively expensive `fmt.Sprintf` and `fmt.Sscanf` functions, see below.

#### Before `KeyFormat` introduction
```shell
go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tendermint/iavl
BenchmarkNodeKey-8                 	 5000000	       316 ns/op
BenchmarkOrphanKey-8               	 2000000	       613 ns/op
ok, starting
BenchmarkImmutableAvlTreeMemDB-8   	200	   5783362 ns/op	 1104190 B/op	   22488 allocs/op
BenchmarkTreeLoadAndDelete/LoadAndDelete-8         	       2	 707800784 ns/op
PASS
ok  	github.com/tendermint/iavl	129.478s
```

#### After `KeyFormat` introduction
```shell
go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/tendermint/iavl
BenchmarkNodeKey-8                 	30000000	        50.9 ns/op
BenchmarkOrphanKey-8               	 5000000	       256 ns/op
BenchmarkImmutableAvlTreeMemDB-8   	     500	   4048465 ns/op	   82591 B/op	    1546 allocs/op
BenchmarkTreeLoadAndDelete/LoadAndDelete-8         	       5	 641415439 ns/op
PASS
ok  	github.com/tendermint/iavl	121.982s
```

For `BenchmarkTreeLoadAndDelete/LoadAndDelete-8` we have 1 - 641415439/707800784 ~= 9.3%