### PR TITLE
update tendermint dependency to v0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.1 (February 12, 2019)
+
+IMPROVEMENTS
+
+ - Use Tendermint v0.30
+
 ## 0.12.0 (November 26, 2018)
 
 BREAKING CHANGES

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -138,7 +138,7 @@
   version = "v0.14.1"
 
 [[projects]]
-  digest = "1:a0fe2dfa98e218733ef751fcdfaceaac7192776020dd64c0cedc84daa07199d6"
+  digest = "1:3a5534ddb8fc03a15819d4862a51ff8f1532c764220e37e16306cd299286abce"
   name = "github.com/tendermint/tendermint"
   packages = [
     "crypto/merkle",
@@ -149,8 +149,8 @@
     "libs/test",
   ]
   pruneopts = "UT"
-  revision = "44b769b1acd0b2aaa8c199b0885bc2811191fb2e"
-  version = "v0.27.0-dev1"
+  revision = "28d75ec8016b7fb043735cbe4c4d92ec73355de7"
+  version = "v0.30.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.27.0-dev1"
+  version = "v0.30.0"
 
 [prune]
   go-tests = true

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package iavl
 
 // Version of iavl.
-const Version = "0.12.0"
+const Version = "0.12.1"


### PR DESCRIPTION
update to tendermint v0.30 and bump version to 0.12.1 (for immediate release)

Dependency to  tendermint v0.27.0-dev1 was causing some inconvenience when developing an app which has the sdk and iavl as a dependency.

cc @alessio