### PR TITLE
close batch after write in nodedb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -138,7 +138,7 @@
   version = "v0.14.1"
 
 [[projects]]
-  digest = "1:3a5534ddb8fc03a15819d4862a51ff8f1532c764220e37e16306cd299286abce"
+  digest = "1:a6aac3f7648efcb988361ce8df6da4f1a4dd80a51ca06d69a3e7d91ec5861bdb"
   name = "github.com/tendermint/tendermint"
   packages = [
     "crypto/merkle",
@@ -149,8 +149,8 @@
     "libs/test",
   ]
   pruneopts = "UT"
-  revision = "28d75ec8016b7fb043735cbe4c4d92ec73355de7"
-  version = "v0.30.0"
+  revision = "976819537d199aa43c6ad55ec4e8958323322bb0"
+  version = "v0.30.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.30.0"
+  version = "v0.30.2"
 
 [prune]
   go-tests = true

--- a/nodedb.go
+++ b/nodedb.go
@@ -330,6 +330,7 @@ func (ndb *nodeDB) Commit() {
 	defer ndb.mtx.Unlock()
 
 	ndb.batch.Write()
+	ndb.batch.Close()
 	ndb.batch = ndb.db.NewBatch()
 }
 


### PR DESCRIPTION
This one is related to https://github.com/tendermint/tendermint/pull/3397, that writebatch should be closed if no longer needed. This one could be the major part of memory leaking when use CLevelDB, since it's in the hot loop.