### PR TITLE
Not increasing the version when the tree is identical 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PDFFLAGS := -pdf --nodefraction=0.1
 all: get_vendor_deps test
 
 test:
-	go clean -testcache
-	go test -v --race
+	GOCACHE=off go test -v --race
+
 
 tools:
 	go get -u -v $(GOTOOLS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ PDFFLAGS := -pdf --nodefraction=0.1
 all: get_vendor_deps test
 
 test:
-	GOCACHE=off go test -v --race
+	go clean -testcache
+	go test -v --race
 
 tools:
 	go get -u -v $(GOTOOLS)

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -320,6 +320,10 @@ func (tree *MutableTree) GetVersioned(key []byte, version int64) (
 // SaveVersion saves a new tree version to disk, based on the current state of
 // the tree. Returns the hash and new version number.
 func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
+	if bytes.Compare(tree.lastSaved.Hash(), tree.WorkingHash()) == 0 {
+		return tree.lastSaved.Hash(), tree.version, nil
+	}
+
 	version := tree.version + 1
 
 	if tree.versions[version] {


### PR DESCRIPTION
When the tree is same as previous version, saving version won't change the version. Fixing #128