### PR TITLE
LoadVersionForOverwriting should transit orphans to non-orphans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Special thanks to external contributors on this release:
 
 ### Bug Fixes
 
+- [orphans] [\#145](https://github.com/tendermint/iavl/pull/145) LoadVersionForOverwriting transits orphans to non-orphans for overwriting version and removes nodes, which become useless  
+
 ## 0.13.3 (April 5, 2020)
 
 ### Bug Fixes

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -574,6 +574,7 @@ func (tree *MutableTree) deleteVersionsFrom(version int64) error {
 	tree.ndb.resetLatestVersion(newLatestVersion)
 	return nil
 }
+
 // deleteNodes deletes all nodes which have greater version than current, because they are not useful anymore
 func (tree *MutableTree) deleteNodes(version int64, hash []byte) {
 	if len(hash) == 0 {
@@ -597,7 +598,6 @@ func (tree *MutableTree) deleteNodes(version int64, hash []byte) {
 		}
 	}
 }
-
 
 // Rotate right and return the new node and orphan.
 func (tree *MutableTree) rotateRight(node *Node) (*Node, *Node) {

--- a/nodedb.go
+++ b/nodedb.go
@@ -748,6 +748,19 @@ func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node)) {
 	}
 }
 
+// restoreNodes restores nodes, which was orphaned, but after overwriting should not be orphans anymore
+func (ndb *nodeDB) restoreNodes(version int64) {
+	traverseOrphansVersionFromDB(ndb.recentDB, version, func(key, hash []byte) {
+		// Delete orphan key and reverse-lookup key.
+		ndb.recentBatch.Delete(key)
+	})
+
+	traverseOrphansVersionFromDB(ndb.snapshotDB, version, func(key, hash []byte) {
+		// Delete orphan key and reverse-lookup key.
+		ndb.snapshotBatch.Delete(key)
+	})
+}
+
 func (ndb *nodeDB) traverseNodesFromDB(db dbm.DB, fn func(hash []byte, node *Node)) {
 	nodes := []*Node{}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1373,3 +1373,34 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 		}
 	})
 }
+func TestLoadVersionForOverwritingCase2(t *testing.T) {
+	require := require.New(t)
+
+	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), db.NewMemDB(), 0, PruningOptions(1, 0))
+
+	tree.Set([]byte{0x1}, []byte{0x1})
+
+	_, _, err := tree.SaveVersion()
+	require.NoError(err, "SaveVersion should not fail")
+
+	tree.Set([]byte{0x1}, []byte{0x2})
+
+	_, _, err = tree.SaveVersion()
+	require.NoError(err, "SaveVersion should not fail with the same key")
+
+	_, err = tree.LoadVersionForOverwriting(1)
+	require.NoError(err, "LoadVersionForOverwriting should not fail")
+
+	tree.Set([]byte{0x2}, []byte{0x3})
+
+	_, _, err = tree.SaveVersion()
+	require.NoError(err, "SaveVersion should not fail")
+
+	err = tree.DeleteVersion(1)
+	require.NoError(err, "DeleteVersion should not fail")
+
+	tree.Set([]byte{0x1}, []byte{0x3})
+
+	_, _, err = tree.SaveVersion()
+	require.NoError(err, "SaveVersion should not fail")
+}


### PR DESCRIPTION
LoadVersionForOverwriting should transit orphans to non-orphans for overwriting version and remove nodes, which become useless

Fixes https://github.com/tendermint/iavl/issues/141