### PR TITLE
Storing intermediary IAVL versions in memory and not to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Pending
+
+- [IAVL] Ability to store temporary versions in memory only, and flush to disk every X versions. This should greatly reduce IO requirements and disk storage. (@mattkanwisher Loom Network)
+
 ## 0.12.2 (March 13, 2019)
 
 IMPROVEMENTS

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -16,6 +16,7 @@ type MutableTree struct {
 	*ImmutableTree                  // The current, working tree.
 	lastSaved      *ImmutableTree   // The most recently saved tree.
 	orphans        map[string]int64 // Nodes removed by changes to working tree.
+	memVersions    map[int64]bool   // The previous, saved versions of the tree in mem.
 	versions       map[int64]bool   // The previous, saved versions of the tree.
 	ndb            *nodeDB
 }
@@ -29,6 +30,7 @@ func NewMutableTree(db dbm.DB, cacheSize int) *MutableTree {
 		ImmutableTree: head,
 		lastSaved:     head.clone(),
 		orphans:       map[string]int64{},
+		memVersions:   map[int64]bool{},
 		versions:      map[int64]bool{},
 		ndb:           ndb,
 	}
@@ -364,10 +366,36 @@ func (tree *MutableTree) GetVersioned(key []byte, version int64) (
 	return -1, nil
 }
 
+// SaveVersionMem saves a new tree version to disk, based on the current state of
+// the tree. Returns the hash and new version number.
+func (tree *MutableTree) SaveVersionMem() ([]byte, int64, error) {
+	return tree.saveVersion(false)
+}
+
+// FlushMemDisk saves a new tree to disk and removes all the versions in memory
+func (tree *MutableTree) FlushMemVersionDisk() ([]byte, int64, error) {
+	x, y, err := tree.saveVersion(true)
+	tree.ndb.dbMem = dbm.NewMemDB()
+	tree.memVersions = map[int64]bool{}
+	tree.ndb.memNodes = map[string]*Node{}
+	return x, y, err
+}
+
 // SaveVersion saves a new tree version to disk, based on the current state of
 // the tree. Returns the hash and new version number.
 func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
+	return tree.saveVersion(true)
+}
+
+func (tree *MutableTree) saveVersion(flushToDisk bool) ([]byte, int64, error) {
 	version := tree.version + 1
+
+	if flushToDisk {
+		tree.ndb.batch = tree.ndb.db.NewBatch()
+	} else {
+		tree.ndb.batch = tree.ndb.dbMem.NewBatch()
+		tree.memVersions[version] = true
+	}
 
 	if tree.versions[version] {
 		//version already exists, throw an error if attempting to overwrite
@@ -389,13 +417,15 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		// There can still be orphans, for example if the root is the node being
 		// removed.
 		debug("SAVE EMPTY TREE %v\n", version)
-		tree.ndb.SaveOrphans(version, tree.orphans)
+		// Assume orphans not needed any more. So don't save any
+		tree.ndb.SaveOrphans(version, tree.orphans, flushToDisk)
 		tree.ndb.SaveEmptyRoot(version)
 	} else {
 		debug("SAVE TREE %v\n", version)
 		// Save the current tree.
-		tree.ndb.SaveBranch(tree.root)
-		tree.ndb.SaveOrphans(version, tree.orphans)
+		tree.ndb.SaveBranch(tree.root, flushToDisk)
+		// Assume orphans not needed any more. So don't save any
+		tree.ndb.SaveOrphans(version, tree.orphans, flushToDisk)
 		tree.ndb.SaveRoot(tree.root, version)
 	}
 	tree.ndb.Commit()
@@ -413,6 +443,23 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 // DeleteVersion deletes a tree version from disk. The version can then no
 // longer be accessed.
 func (tree *MutableTree) DeleteVersion(version int64) error {
+	return tree.DeleteVersionFull(version, true)
+}
+
+// DeleteVersionFull deletes a tree version from disk or memory based on the flag. The version can then no
+// longer be accessed.
+func (tree *MutableTree) DeleteVersionFull(version int64, memDeleteAlso bool) error {
+	if tree.memVersions[version] {
+		//sometimes you dont want to bother deleting versions in memory
+		if !memDeleteAlso {
+			return nil
+		}
+		tree.ndb.batch = tree.ndb.dbMem.NewBatch()
+		delete(tree.memVersions, version)
+	} else {
+		tree.ndb.batch = tree.ndb.db.NewBatch()
+	}
+
 	if version == 0 {
 		return cmn.NewError("version must be greater than 0")
 	}

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1,0 +1,32 @@
+package iavl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/db"
+)
+
+func TestDelete(t *testing.T) {
+	memDb := db.NewMemDB()
+	tree := NewMutableTree(memDb, 0)
+
+	tree.set([]byte("k1"), []byte("Fred"))
+	hash, version, err := tree.SaveVersion()
+	require.NoError(t, err)
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	require.NoError(t, tree.DeleteVersion(version))
+
+	k1Value, _, err := tree.GetVersionedWithProof([]byte("k1"), version)
+	require.Nil(t, k1Value)
+
+	key := tree.ndb.rootKey(version)
+	memDb.Set(key, hash)
+	tree.versions[version] = true
+
+	k1Value, _, err = tree.GetVersionedWithProof([]byte("k1"), version)
+	require.Equal(t, 0, bytes.Compare([]byte("Fred"), k1Value))
+}

--- a/node.go
+++ b/node.go
@@ -15,17 +15,18 @@ import (
 
 // Node represents a node in a Tree.
 type Node struct {
-	key       []byte
-	value     []byte
-	version   int64
-	height    int8
-	size      int64
-	hash      []byte
-	leftHash  []byte
-	leftNode  *Node
-	rightHash []byte
-	rightNode *Node
-	persisted bool
+	key          []byte
+	value        []byte
+	version      int64
+	height       int8
+	size         int64
+	hash         []byte
+	leftHash     []byte
+	leftNode     *Node
+	rightHash    []byte
+	rightNode    *Node
+	persisted    bool
+	persistedMem bool
 }
 
 // NewNode returns a new node from a key, value and version.

--- a/nodedb.go
+++ b/nodedb.go
@@ -190,7 +190,7 @@ func (ndb *nodeDB) SaveOrphans(version int64, orphans map[string]int64, flushToD
 	defer ndb.mtx.Unlock()
 
 	var toVersion int64
-	toVersion = ndb.getPreviousVersioni(version, ndb.dbMem)
+	toVersion = ndb.getPreviousVersionDB(version, ndb.dbMem)
 	if toVersion == 0 {
 		toVersion = ndb.getPreviousVersion(version)
 	} //see if we have something on disk if we dont have anything from mem

--- a/nodedb.go
+++ b/nodedb.go
@@ -190,7 +190,7 @@ func (ndb *nodeDB) SaveOrphans(version int64, orphans map[string]int64, flushToD
 	defer ndb.mtx.Unlock()
 
 	var toVersion int64
-	toVersion = ndb.getPreviousVersionDB(version, ndb.dbMem)
+	toVersion = ndb.getPreviousVersionFromDB(version, ndb.dbMem)
 	if toVersion == 0 {
 		toVersion = ndb.getPreviousVersion(version)
 	} //see if we have something on disk if we dont have anything from mem


### PR DESCRIPTION
Storing intermediary IAVL versions in memory and not to disk

Motivation: Both Cosmos and Loom Network save an IAVL version per block, then go back and delete these versions. So you have constant churn on the IAVL and underlying Leveldb database. When realistically what you want is to only store every X Blocks.

At Berlin Tendermint Conference, Zaki and I surmised a plan where new versions are in memory, while still pointing back to nodes on disk to prevent needing to load entire IAVL into main memory. Loom IAVL tree is around 256gb so this is not feasible otherwise.


Usage

OLD Code would be like

```go
hash, version, err := s.tree.SaveVersion()
```

New Caller code would look like

```go
	oldVersion := s.Version()
  	var version int64
 	var hash []byte
 	//Every X versions we should persist to disk
 	if s.flushInterval == 0 || ((oldVersion+1)%s.flushInterval == 0) {
 		if s.flushInterval != 0 {
 			log.Error(fmt.Sprintf("Flushing mem to disk at version %d\n", oldVersion+1))
 			hash, version, err = s.tree.FlushMemVersionDisk()
 		} else {
 			hash, version, err = s.tree.SaveVersion()
 		}
 	} else {
 		hash, version, err = s.tree.SaveVersionMem()
 	}
```

FlushMemVersionDisk:
Flushes the current memory version to disk

SaveVersionMem:
Saves the current tree to memory instead of disk and gives you back an apphash

This is an opt in feature, you have to call new apis to get it. 
We also have a PR that demonstrates its usage https://github.com/loomnetwork/loomchain/pull/1232/files

We are now commiting every 1000 blocks, so we store 1000x less. Also we have signficant improves in IO at least double from not having to Prune old versions of the IAVL Tree