### PR TITLE
Iavl rollback: not ready for merge

### DIFF
--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -206,7 +206,7 @@ func GetSubStores(db dbm.DB, ver int64) ([]string, error) {
 		return nil, err
 	}
 
-	var res []string
+	res := make([]string, len(cInfo.StoreInfos))
 	for _, sinfo := range cInfo.StoreInfos {
 		res = append(res, sinfo.Name)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tendermint/iavl
 go 1.12
 
 require (
+	github.com/gogo/protobuf v1.2.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/tendermint/go-amino v0.14.1


### PR DESCRIPTION
This is an experimental script to undo the last few blocks of an sdk store.
Useful when you have the wrong version of the software and get
`ERROR: Error during handshake: Error on replay: Wrong Block.Header.AppHash.` on startup.

Usage:

1. Compile script
2. Look for the abci app database (it should be `data/application.db`, you need the full path)
3. Stop your blockchain daemon
4. Check we can read the application db
5. Roll it back
6. Check it was updated
7. Restart application daemon.

This was inspired by issues with regen network's upgrade... so some info my be regen specific.

## Details

Compile Script:

```console
git clone https://github.com/confio/iavl
cd iavl
git checkout iavl-rollback
GO111MODULES=on go install ./cmd/iaviewer

# this should show a just built binary
ls -l `which iaviewer`
```

Check state: `iaviewer stores <PATH TO application.db>`
You should see the last height and all stores

Roll back two blocks: `iaviewer rollback <PATH TO application.db>`

Check state again: `iaviewer stores <PATH TO application.db>`
You should see the latest height is 2 less, but all stores still listed

Once this is valid, restart `xrnd` *v0.4.0* and wait for it to hit the upgrade block (953626).
Then you can stop it, upgrade to *v0.4.1* and continue with no more consensus issues
