### PR TITLE
pre-allocate memory for collecting orphan nodes

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -266,15 +266,19 @@ func runSuite(b *testing.B, d db.DB, initSize, blockSize, keyLen, dataLen int) {
 	b.ResetTimer()
 
 	b.Run("query-miss", func(sub *testing.B) {
+		sub.ReportAllocs()
 		runQueries(sub, t, keyLen)
 	})
 	b.Run("query-hits", func(sub *testing.B) {
+		sub.ReportAllocs()
 		runKnownQueries(sub, t, keys)
 	})
 	b.Run("update", func(sub *testing.B) {
+		sub.ReportAllocs()
 		t = runUpdate(sub, t, dataLen, blockSize, keys)
 	})
 	b.Run("block", func(sub *testing.B) {
+		sub.ReportAllocs()
 		t = runBlock(sub, t, keyLen, dataLen, blockSize, keys)
 	})
 

--- a/benchmarks/results/168/Rickys-MBP-0.12.4-4-g494d60b-result.txt
+++ b/benchmarks/results/168/Rickys-MBP-0.12.4-4-g494d60b-result.txt
@@ -1,0 +1,69 @@
+go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-4-g494d60b -X github.com/tendermint/iavl.Commit=494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6 -X github.com/tendermint/iavl.Branch=master" -bench=MutableTree_Set .
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl
+BenchmarkMutableTree_Set-12       300000              5936 ns/op            4454 B/op         25 allocs/op
+PASS
+ok      github.com/tendermint/iavl      33.943s
+cd benchmarks && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-4-g494d60b -X github.com/tendermint/iavl.Commit=494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6 -X github.com/tendermint/iavl.Branch=master" -bench=RandomBytes . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-4-g494d60b -X github.com/tendermint/iavl.Commit=494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6 -X github.com/tendermint/iavl.Branch=master" -bench=Small . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-4-g494d60b -X github.com/tendermint/iavl.Commit=494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6 -X github.com/tendermint/iavl.Branch=master" -bench=Medium . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-4-g494d60b -X github.com/tendermint/iavl.Commit=494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6 -X github.com/tendermint/iavl.Branch=master" -bench=BenchmarkMemKeySizes .
+iavl: 0.12.4-4-g494d60b
+git commit: 494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6
+git branch: master
+go version go1.12.5 darwin/amd64
+
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkRandomBytes/random-4-12                30000000                37.5 ns/op
+BenchmarkRandomBytes/random-16-12               30000000                55.1 ns/op
+BenchmarkRandomBytes/random-32-12               20000000                76.4 ns/op
+BenchmarkRandomBytes/random-100-12              10000000               171 ns/op
+BenchmarkRandomBytes/random-1000-12              1000000              1338 ns/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   7.739s
+iavl: 0.12.4-4-g494d60b
+git commit: 494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6
+git branch: master
+go version go1.12.5 darwin/amd64
+
+Init Tree took 0.90 MB
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkSmall/memdb-1000-100-4-10/query-miss-12                 1000000              1814 ns/op             353 B/op          7 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/query-hits-12                 1000000              2087 ns/op             515 B/op          9 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/update-12                       20000             76006 ns/op           47671 B/op        843 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/block-12                          100          11481861 ns/op         6581560 B/op     118259 allocs/op
+Init Tree took 0.49 MB
+BenchmarkSmall/goleveldb-1000-100-4-10/query-miss-12              500000              2903 ns/op             575 B/op         12 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/query-hits-12              500000              3533 ns/op             788 B/op         15 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/update-12                   30000             59931 ns/op           23571 B/op        247 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/block-12                      200          13931032 ns/op         4455199 B/op      52266 allocs/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   16.641s
+iavl: 0.12.4-4-g494d60b
+git commit: 494d60be6833a7bde8e4b8ddf3ad8d2a9df662c6
+git branch: master
+go version go1.12.5 darwin/amd64
+
+Init Tree took 85.03 MB
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkMedium/memdb-100000-100-16-40/query-miss-12              200000              6072 ns/op             426 B/op          8 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/query-hits-12              200000              6660 ns/op             557 B/op          9 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/update-12                    5000            891292 ns/op          308110 B/op       6016 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/block-12                       10         119351442 ns/op        39926731 B/op     791429 allocs/op
+Init Tree took 47.50 MB
+BenchmarkMedium/goleveldb-100000-100-16-40/query-miss-12          100000             16961 ns/op            1592 B/op         28 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/query-hits-12          100000             21351 ns/op            2209 B/op         38 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/update-12               10000            193156 ns/op           48430 B/op        616 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/block-12                   50          28373250 ns/op         5519076 B/op      73151 allocs/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   21.117s
+PASS
+ok      github.com/tendermint/iavl/benchmarks   0.009s

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1,0 +1,24 @@
+package iavl
+
+import (
+	"runtime"
+	"testing"
+
+	db "github.com/tendermint/tm-db"
+)
+
+func BenchmarkMutableTree_Set(b *testing.B) {
+	db := db.NewDB("test", db.MemDBBackend, "")
+	t := NewMutableTree(db, 100000)
+	for i := 0; i < 1000000; i++ {
+		t.Set(randBytes(10), []byte{})
+	}
+	b.ReportAllocs()
+	runtime.GC()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		t.Set(randBytes(10), []byte{})
+	}
+}


### PR DESCRIPTION
estimate and pre-allocate the space for the orphaned nodes. It really matters when the tree become higher and higher and we have frequent set/remove operations.

benchmark
```
before:
BenchmarkMutableTree_Set-12    	  200000	      8845 ns/op	    6359 B/op	      65 allocs/op

after:
BenchmarkMutableTree_Set-12    	  300000	      5339 ns/op	    4604 B/op	      25 allocs/op
```