### PR TITLE
preallocate memory for node serialization when SaveNode

### DIFF
--- a/benchmarks/results/169/Rickys-MBP-0.12.4-3-ge247ad9-results.txt
+++ b/benchmarks/results/169/Rickys-MBP-0.12.4-3-ge247ad9-results.txt
@@ -1,0 +1,72 @@
+go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-3-ge247ad9 -X github.com/tendermint/iavl.Commit=e247ad97f779f28abbe31b05d8cbc8b62aa6994b -X github.com/tendermint/iavl.Branch=node_value" -bench=Node* .
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl
+BenchmarkNode_aminoSize-12      200000000                8.72 ns/op            0 B/op          0 allocs/op
+BenchmarkNode_WriteBytes/NoPreAllocate-12                5000000               373 ns/op             368 B/op          9 allocs/op
+BenchmarkNode_WriteBytes/PreAllocate-12                  5000000               328 ns/op             224 B/op          8 allocs/op
+BenchmarkNodeKey-12                                     30000000                47.1 ns/op
+PASS
+ok      github.com/tendermint/iavl      21.170s
+cd benchmarks && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-3-ge247ad9 -X github.com/tendermint/iavl.Commit=e247ad97f779f28abbe31b05d8cbc8b62aa6994b -X github.com/tendermint/iavl.Branch=node_value" -bench=RandomBytes . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-3-ge247ad9 -X github.com/tendermint/iavl.Commit=e247ad97f779f28abbe31b05d8cbc8b62aa6994b -X github.com/tendermint/iavl.Branch=node_value" -bench=Small . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-3-ge247ad9 -X github.com/tendermint/iavl.Commit=e247ad97f779f28abbe31b05d8cbc8b62aa6994b -X github.com/tendermint/iavl.Branch=node_value" -bench=Medium . && \
+                go test -ldflags "-X github.com/tendermint/iavl.Version=0.12.4-3-ge247ad9 -X github.com/tendermint/iavl.Commit=e247ad97f779f28abbe31b05d8cbc8b62aa6994b -X github.com/tendermint/iavl.Branch=node_value" -bench=BenchmarkMemKeySizes .
+iavl: 0.12.4-3-ge247ad9
+git commit: e247ad97f779f28abbe31b05d8cbc8b62aa6994b
+git branch: node_value
+go version go1.12.5 darwin/amd64
+
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkRandomBytes/random-4-12                30000000                36.5 ns/op
+BenchmarkRandomBytes/random-16-12               30000000                53.5 ns/op
+BenchmarkRandomBytes/random-32-12               20000000                76.7 ns/op
+BenchmarkRandomBytes/random-100-12              10000000               167 ns/op
+BenchmarkRandomBytes/random-1000-12              1000000              1345 ns/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   7.627s
+iavl: 0.12.4-3-ge247ad9
+git commit: e247ad97f779f28abbe31b05d8cbc8b62aa6994b
+git branch: node_value
+go version go1.12.5 darwin/amd64
+
+Init Tree took 0.82 MB
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkSmall/memdb-1000-100-4-10/query-miss-12                 1000000              1787 ns/op             353 B/op          7 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/query-hits-12                 1000000              2138 ns/op             514 B/op          9 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/update-12                       20000             74001 ns/op           47666 B/op        860 allocs/op
+BenchmarkSmall/memdb-1000-100-4-10/block-12                          100          11359815 ns/op         6558684 B/op     119840 allocs/op
+Init Tree took 0.48 MB
+BenchmarkSmall/goleveldb-1000-100-4-10/query-miss-12              500000              2800 ns/op             556 B/op         11 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/query-hits-12              500000              3477 ns/op             787 B/op         15 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/update-12                   30000             61296 ns/op           23580 B/op        263 allocs/op
+BenchmarkSmall/goleveldb-1000-100-4-10/block-12                      200          14048236 ns/op         4472449 B/op      54353 allocs/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   17.569s
+iavl: 0.12.4-3-ge247ad9
+git commit: e247ad97f779f28abbe31b05d8cbc8b62aa6994b
+git branch: node_value
+go version go1.12.5 darwin/amd64
+
+Init Tree took 78.64 MB
+goos: darwin
+goarch: amd64
+pkg: github.com/tendermint/iavl/benchmarks
+BenchmarkMedium/memdb-100000-100-16-40/query-miss-12              200000              5764 ns/op             426 B/op          8 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/query-hits-12              200000              6485 ns/op             557 B/op          9 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/update-12                    5000            892383 ns/op          308163 B/op       6040 allocs/op
+BenchmarkMedium/memdb-100000-100-16-40/block-12                       10         120660641 ns/op        39925867 B/op     793685 allocs/op
+Init Tree took 46.84 MB
+BenchmarkMedium/goleveldb-100000-100-16-40/query-miss-12          100000             17000 ns/op            1592 B/op         28 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/query-hits-12          100000             20677 ns/op            2209 B/op         38 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/update-12               10000            189551 ns/op           48464 B/op        639 allocs/op
+BenchmarkMedium/goleveldb-100000-100-16-40/block-12                   50          25864961 ns/op         5432798 B/op      74492 allocs/op
+PASS
+ok      github.com/tendermint/iavl/benchmarks   21.234s
+PASS
+ok      github.com/tendermint/iavl/benchmarks   0.008s

--- a/node.go
+++ b/node.go
@@ -301,6 +301,20 @@ func (node *Node) writeHashBytesRecursively(w io.Writer) (hashCount int64, err e
 	return
 }
 
+func (node *Node) aminoSize() int {
+	n := 1 +
+		amino.VarintSize(node.size) +
+		amino.VarintSize(node.version) +
+		amino.ByteSliceSize(node.key)
+	if node.isLeaf() {
+		n += amino.ByteSliceSize(node.value)
+	} else {
+		n += amino.ByteSliceSize(node.leftHash) +
+			amino.ByteSliceSize(node.rightHash)
+	}
+	return n
+}
+
 // Writes the node as a serialized byte slice to the supplied io.Writer.
 func (node *Node) writeBytes(w io.Writer) error {
 	cause := amino.EncodeInt8(w, node.height)

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,96 @@
+package iavl
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_aminoSize(t *testing.T) {
+	node := &Node{
+		key:       randBytes(10),
+		value:     randBytes(10),
+		version:   1,
+		height:    0,
+		size:      100,
+		hash:      randBytes(20),
+		leftHash:  randBytes(20),
+		leftNode:  nil,
+		rightHash: randBytes(20),
+		rightNode: nil,
+		persisted: false,
+	}
+
+	// leaf node
+	var buf bytes.Buffer
+	err := node.writeBytes(&buf)
+	require.NoError(t, err)
+	require.Equal(t, buf.Len(), node.aminoSize())
+
+	// non-leaf node
+	node.height = 1
+	buf.Reset()
+	err = node.writeBytes(&buf)
+	require.NoError(t, err)
+	require.Equal(t, buf.Len(), node.aminoSize())
+}
+
+func BenchmarkNode_aminoSize(b *testing.B) {
+	b.StopTimer()
+	node := &Node{
+		key:       randBytes(25),
+		value:     randBytes(100),
+		version:   rand.Int63n(10000000),
+		height:    1,
+		size:      rand.Int63n(10000000),
+		leftHash:  randBytes(20),
+		rightHash: randBytes(20),
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		node.aminoSize()
+	}
+}
+
+func BenchmarkNode_WriteBytes(b *testing.B) {
+	b.StopTimer()
+	node := &Node{
+		key:       randBytes(25),
+		value:     randBytes(100),
+		version:   rand.Int63n(10000000),
+		height:    1,
+		size:      rand.Int63n(10000000),
+		leftHash:  randBytes(20),
+		rightHash: randBytes(20),
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		buf.Reset()
+		_ = node.writeBytes(&buf)
+	}
+}
+
+func BenchmarkNode_WriteBytesPrealloc(b *testing.B) {
+	b.StopTimer()
+	node := &Node{
+		key:       randBytes(25),
+		value:     randBytes(100),
+		version:   rand.Int63n(10000000),
+		height:    1,
+		size:      rand.Int63n(10000000),
+		leftHash:  randBytes(20),
+		rightHash: randBytes(20),
+	}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		buf.Grow(node.aminoSize())
+		_ = node.writeBytes(&buf)
+	}
+}

--- a/nodedb.go
+++ b/nodedb.go
@@ -103,8 +103,9 @@ func (ndb *nodeDB) SaveNode(node *Node) {
 	}
 
 	// Save node bytes to db.
-	buf := new(bytes.Buffer)
-	if err := node.writeBytes(buf); err != nil {
+	var buf bytes.Buffer
+	buf.Grow(node.aminoSize())
+	if err := node.writeBytes(&buf); err != nil {
 		panic(err)
 	}
 	ndb.batch.Set(ndb.nodeKey(node.hash), buf.Bytes())


### PR DESCRIPTION
pre-calculate the buffer size and allocate before serializing the node.

```
BenchmarkNode_aminoSize-12             	200000000	         8.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkNode_WriteBytes-12            	 5000000	       371 ns/op	     368 B/op	       9 allocs/op
BenchmarkNode_WriteBytesPrealloc-12    	 5000000	       322 ns/op	     224 B/op	       8 allocs/op
```
note this benchmark needs another PR from go-amino which accelerates the VarintSize() method
https://github.com/tendermint/go-amino/pull/282/files