### PR TITLE
bugfix: orphans are not totally collected when Remove

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -207,10 +207,11 @@ func (tree *MutableTree) recursiveRemove(node *Node, key []byte, orphans *[]*Nod
 
 		if len(*orphans) == 0 {
 			return node.hash, node, nil, value
-		} else if newLeftHash == nil && newLeftNode == nil { // left node held value, was removed
-			return node.rightHash, node.rightNode, node.key, value
 		}
 		*orphans = append(*orphans, node)
+		if newLeftHash == nil && newLeftNode == nil { // left node held value, was removed
+			return node.rightHash, node.rightNode, node.key, value
+		}
 
 		newNode := node.clone(version)
 		newNode.leftHash, newNode.leftNode = newLeftHash, newLeftNode
@@ -223,10 +224,11 @@ func (tree *MutableTree) recursiveRemove(node *Node, key []byte, orphans *[]*Nod
 
 	if len(*orphans) == 0 {
 		return node.hash, node, nil, value
-	} else if newRightHash == nil && newRightNode == nil { // right node held value, was removed
-		return node.leftHash, node.leftNode, nil, value
 	}
 	*orphans = append(*orphans, node)
+	if newRightHash == nil && newRightNode == nil { // right node held value, was removed
+		return node.leftHash, node.leftNode, nil, value
+	}
 
 	newNode := node.clone(version)
 	newNode.rightHash, newNode.rightNode = newRightHash, newRightNode

--- a/tree_test.go
+++ b/tree_test.go
@@ -360,7 +360,7 @@ func TestVersionedTree(t *testing.T) {
 
 	nodes3 := tree.ndb.leafNodes()
 	require.Len(nodes3, 6, "wrong number of nodes")
-	require.Len(tree.ndb.orphans(), 6, "wrong number of orphans")
+	require.Len(tree.ndb.orphans(), 7, "wrong number of orphans")
 
 	hash4, _, _ := tree.SaveVersion()
 	require.EqualValues(hash3, hash4)


### PR DESCRIPTION
Details:
## Summary:
`Remove` operation will leave some orphans not collected. So these orphans would never be pruned from database. So many nodeDB operations would get the wrong result, like `traverse`, `traversePrefix`, `traverseNodes`, `size()`, etc.
 
## Steps To Reproduce:

  1. Run the test code

```go
func TestMutableTree_Remove(t *testing.T) {
	db := db.NewDB("test", db.MemDBBackend, "")
	tree := NewMutableTree(db, 0)
	tree.Set([]byte("k1"), []byte("v1"))
	tree.Set([]byte("k2"), []byte("v1"))
	tree.Set([]byte("k3"), []byte("v1"))
	tree.Set([]byte("k4"), []byte("v1"))
	tree.Set([]byte("k5"), []byte("v1"))
	tree.SaveVersion()
	tree.Remove([]byte("k5"))
	require.Equal(t, 4, len(tree.orphans))
	tree.SaveVersion()
}
```

The test will failed because the `Remove` only collect 3 orphans instead of the expected 4.
The tree looks like this

```
           3                                                3
         /   \                                            /   \    
        2      4                                         2     4
      /  \    /  \                =>                   /  \   /  \
     1    2  3    5                                  1   2  3    4
                 /  \
                4    5
```

The orphans should be [5, 5, 4, 3],  but we got [5,4,3] instead. The inner node `5` is lost.
