### PR TITLE
Fix concurrent database access when deleting orphans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Special thanks to external contributors on this release:
 
 ### Bug Fix
 
-- [nodedb] Fix a concurrency issue while deleting orphans
+- [nodedb] [\#219](https://github.com/tendermint/iavl/pull/219) Fix a concurrent database access issue when deleting orphans
 
 ## 0.13.0 (January 16, 2020)
 
@@ -19,7 +19,7 @@ Special thanks to external contributors on this release:
 
 ### BREAKING CHANGES
 
-- [pruning] [/#158](https://github.com/tendermint/iavl/pull/158) NodeDB constructor must provide `keepRecent` and `keepEvery` fields to define PruningStrategy. All Save functionality must specify whether they should flushToDisk as well using `flushToDisk` boolean argument. All Delete functionality must specify whether object should be deleted from memory only using the `memOnly` boolean argument.
+- [pruning] [\#158](https://github.com/tendermint/iavl/pull/158) NodeDB constructor must provide `keepRecent` and `keepEvery` fields to define PruningStrategy. All Save functionality must specify whether they should flushToDisk as well using `flushToDisk` boolean argument. All Delete functionality must specify whether object should be deleted from memory only using the `memOnly` boolean argument.
 - [dep] [\#194](https://github.com/tendermint/iavl/pull/194) Update tm-db to 0.4.0 this includes interface breaking to return errors.
 
 ### IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Special thanks to external contributors on this release:
 
 ### Bug Fix
 
+- [nodedb] Fix a concurrency issue while deleting orphans
+
 ## 0.13.0 (January 16, 2020)
 
 Special thanks to external contributors on this release:

--- a/nodedb.go
+++ b/nodedb.go
@@ -284,16 +284,12 @@ func (ndb *nodeDB) deleteOrphans(version int64, memOnly bool) error {
 	if ndb.opts.KeepRecent != 0 {
 		ndb.deleteOrphansMem(version)
 	}
-	var err error
 	if ndb.isSnapshotVersion(version) && !memOnly {
 		predecessor := getPreviousVersionFromDB(version, ndb.snapshotDB)
 		traverseOrphansVersionFromDB(ndb.snapshotDB, version, func(key, hash []byte) {
-			err = ndb.snapshotDB.Delete(key)
+			ndb.snapshotBatch.Delete(key)
 			ndb.deleteOrphansHelper(ndb.snapshotDB, ndb.snapshotBatch, true, predecessor, key, hash)
 		})
-	}
-	if err != nil {
-		return errors.Wrap(err, "snapshotDB err in delete")
 	}
 	return nil
 }


### PR DESCRIPTION
When deleting orphans, an orphan node is deleted from the database while the database is being iterated over. This breaks the tm-db contract:

> CONTRACT: No writes may happen within a domain while an iterator exists over it.

This caused deadlocks and race conditions with the new [B-tree based MemDB](https://github.com/tendermint/tm-db/pull/53).

I believe this is an oversight, since all of the other related writes are batched in `snapshotBatch` or `recentBatch` instead of writing directly to the database. This change fixes the problem by batching the deletes instead. The tests pass, but I would like a confirmation from someone familiar with this logic.