### PR TITLE
ci: run on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: Test
-name: Test
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Test
-on: [pull_request]
+name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   Test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- run ci when pushed to master
- run always for pull requests
- don't run ci when a branch is merely pushed to the repo