### PR TITLE
README: add GoDoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Test](https://github.com/tendermint/iavl/workflows/Test/badge.svg?branch=master)
 ![Lint](https://github.com/tendermint/iavl/workflows/Lint/badge.svg?branch=master)
+[![](https://godoc.org/github.com/tendermint/iavl?status.svg)](http://godoc.org/github.com/tendermint/iavl)
 
 **Note: Requires Go 1.13+**
 


### PR DESCRIPTION
Should really link to pkg.go.dev, the team is still working on a badge: https://github.com/golang/go/issues/36982