### PR TITLE
doc: specify concurrency characteristics

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,8 +1,13 @@
 // Package iavl implements a versioned, snapshottable (immutable) AVL+ tree
 // for persisting key-value pairs.
 //
+// The tree is not safe for concurrent use, and must be guarded by a Mutex
+// or RWLock as appropriate - the exception is immutable trees returned by
+// MutableTree.GetImmutable() which are safe for concurrent use as long as
+// the version is not deleted via DeleteVersion() or pruning settings.
 //
-// Basic usage of MutableTree.
+//
+// Basic usage of MutableTree:
 //
 //  import "github.com/tendermint/iavl"
 //  import "github.com/tendermint/tm-db"

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -7,16 +7,16 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// ImmutableTree is a container for an immutable AVL+ ImmutableTree. Changes are performed by
-// swapping the internal root with a new one, while the container is mutable.
-// Note that this tree is not thread-safe.
+// ImmutableTree contains the immutable tree at a given version. It is typically created by calling
+// MutableTree.GetImmutable(), in which case the returned tree is safe for concurrent access as
+// long as the version is not deleted via DeleteVersion() or the tree's pruning settings.
 type ImmutableTree struct {
 	root    *Node
 	ndb     *nodeDB
 	version int64
 }
 
-// NewImmutableTree creates both in-memory and persistent instances. Default behavior snapshots every version
+// NewImmutableTree creates both in-memory and persistent instances.
 func NewImmutableTree(db dbm.DB, cacheSize int) *ImmutableTree {
 	if db == nil {
 		// In-memory Tree.


### PR DESCRIPTION
Fixes #241. I ran some tests with the Go race detector, and as far as I can tell these modifications are accurate - however, it's possible I have missed some edge cases.